### PR TITLE
If possible, set assignee to the original PR's author

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -112,15 +112,26 @@ export const createBackportPr = async (
     },
   );
 
-  // set assignees and milestone
+  // set milestone
   await fetch(
     `${GITHUB_API}/repos/go-gitea/gitea/issues/${json.number}`,
     {
       method: "PATCH",
       headers: HEADERS,
       body: JSON.stringify({
-        // assignees: [originalPr.user.login],
         milestone: giteaVersion.milestoneNumber,
+      }),
+    },
+  );
+
+  // set assignee
+  await fetch(
+    `${GITHUB_API}/repos/go-gitea/gitea/issues/${json.number}`,
+    {
+      method: "PATCH",
+      headers: HEADERS,
+      body: JSON.stringify({
+        assignees: [originalPr.user.login],
       }),
     },
   );


### PR DESCRIPTION
The calls are separated to allow the assignee call to fail and still let the milestone call to pass