### PR TITLE
Fix "null" being appended to the body in case the original PR didn't have a body

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -70,6 +70,11 @@ export const createBackportPr = async (
   },
   giteaVersion: GiteaVersion,
 ) => {
+  let prDescription =
+    `Backport #${originalPr.number} by @${originalPr.user.login}`;
+  if (originalPr.body) {
+    prDescription += "\n\n" + originalPr.body;
+  }
   let response = await fetch(`${GITHUB_API}/repos/go-gitea/gitea/pulls`, {
     method: "POST",
     headers: HEADERS,
@@ -82,8 +87,7 @@ export const createBackportPr = async (
         )
       }`,
       base: `release/v${giteaVersion.majorMinorVersion}`,
-      body:
-        `Backport #${originalPr.number} by @${originalPr.user.login}\n\n${originalPr.body}`,
+      body: prDescription,
       maintainer_can_modify: true,
     }),
   });


### PR DESCRIPTION
So https://github.com/go-gitea/gitea/pull/23852 won't happen again

Closes #20