### PR TITLE
Remove `reviewed/wait-merge` and `reviewed/prioritize-merge` labels from merged PRs

### DIFF
--- a/src/backport.ts
+++ b/src/backport.ts
@@ -11,15 +11,6 @@ import {
 } from "./github.ts";
 
 export const run = async () => {
-  if (
-    Deno.env.get("BACKPORTER_GITEA_FORK") === undefined ||
-    Deno.env.get("BACKPORTER_GITHUB_TOKEN") === undefined
-  ) {
-    console.log(
-      "BACKPORTER_GITEA_FORK and BACKPORTER_GITHUB_TOKEN must be set",
-    );
-    return;
-  }
   await initializeGitRepo();
   const milestones = await getMilestones();
   for (const milestone of milestones) {

--- a/src/github.ts
+++ b/src/github.ts
@@ -24,6 +24,28 @@ export const fetchCandidates = async (giteaMajorMinorVersion: string) => {
   return json;
 };
 
+// returns a list of PRs that are merged and have the reviewed/wait-merge
+export const fetchMergedWithReviewedWaitMerge = async () => {
+  const response = await fetch(
+    `${GITHUB_API}/search/issues?q=` +
+      encodeURIComponent(
+        `is:pr is:merged label:reviewed/wait-merge repo:go-gitea/gitea`,
+      ),
+    { headers: HEADERS },
+  );
+  const json = await response.json();
+  return json;
+};
+
+// given a PR number (that was merged and has the reviewed/wait-merge label), remove the label
+export const removeReviewedWaitMergeLabel = async (prNumber: number) => {
+  const response = await fetch(
+    `${GITHUB_API}/repos/go-gitea/gitea/issues/${prNumber}/labels/reviewed/wait-merge`,
+    { method: "DELETE", headers: HEADERS },
+  );
+  return response;
+};
+
 // returns the PR
 export const fetchPr = async (prNumber: number) => {
   const response = await fetch(

--- a/src/github.ts
+++ b/src/github.ts
@@ -24,12 +24,12 @@ export const fetchCandidates = async (giteaMajorMinorVersion: string) => {
   return json;
 };
 
-// returns a list of PRs that are merged and have the reviewed/wait-merge
-export const fetchMergedWithReviewedWaitMerge = async () => {
+// returns a list of PRs that are merged and have the given label
+export const fetchMergedWithLabel = async (label: string) => {
   const response = await fetch(
     `${GITHUB_API}/search/issues?q=` +
       encodeURIComponent(
-        `is:pr is:merged label:reviewed/wait-merge repo:go-gitea/gitea`,
+        `is:pr is:merged label:${label} repo:go-gitea/gitea`,
       ),
     { headers: HEADERS },
   );
@@ -37,10 +37,13 @@ export const fetchMergedWithReviewedWaitMerge = async () => {
   return json;
 };
 
-// given a PR number (that was merged and has the reviewed/wait-merge label), remove the label
-export const removeReviewedWaitMergeLabel = async (prNumber: number) => {
+// given a PR number that has the given label, remove the label
+export const removeLabel = async (
+  prNumber: number,
+  label: string,
+) => {
   const response = await fetch(
-    `${GITHUB_API}/repos/go-gitea/gitea/issues/${prNumber}/labels/reviewed/wait-merge`,
+    `${GITHUB_API}/repos/go-gitea/gitea/issues/${prNumber}/labels/${label}`,
     { method: "DELETE", headers: HEADERS },
   );
   return response;

--- a/src/labels.ts
+++ b/src/labels.ts
@@ -1,0 +1,24 @@
+import {
+  fetchMergedWithReviewedWaitMerge,
+  removeReviewedWaitMergeLabel,
+} from "./github.ts";
+
+export const run = async () => {
+  const prsThatAreMergedAndHaveTheReviewedWaitMergeLabel =
+    await fetchMergedWithReviewedWaitMerge();
+  await Promise.all(
+    prsThatAreMergedAndHaveTheReviewedWaitMergeLabel.items.map(remove),
+  );
+};
+
+const remove = async (pr: { title: string; number: number }) => {
+  const response = await removeReviewedWaitMergeLabel(pr.number);
+  if (response.ok) {
+    console.log(`Removed reviewed/wait-merge from ${pr.title} (#${pr.number})`);
+  } else {
+    console.error(
+      `Failed to remove reviewed/wait-merge from ${pr.title} (#${pr.number})`,
+    );
+    console.error(await response.text());
+  }
+};

--- a/src/labels.ts
+++ b/src/labels.ts
@@ -1,24 +1,36 @@
-import {
-  fetchMergedWithReviewedWaitMerge,
-  removeReviewedWaitMergeLabel,
-} from "./github.ts";
+import { fetchMergedWithLabel, removeLabel } from "./github.ts";
 
 export const run = async () => {
-  const prsThatAreMergedAndHaveTheReviewedWaitMergeLabel =
-    await fetchMergedWithReviewedWaitMerge();
-  await Promise.all(
-    prsThatAreMergedAndHaveTheReviewedWaitMergeLabel.items.map(remove),
-  );
+  const labelsToRemoveAfterMerge = [
+    "reviewed/wait-merge",
+    "reviewed/prioritize-merge",
+  ];
+  await removeLabelsFromMergedPr(labelsToRemoveAfterMerge);
 };
 
-const remove = async (pr: { title: string; number: number }) => {
-  const response = await removeReviewedWaitMergeLabel(pr.number);
+const removeLabelFromMergedPr = async (
+  pr: { title: string; number: number },
+  label: string,
+) => {
+  const response = await removeLabel(pr.number, label);
   if (response.ok) {
-    console.log(`Removed reviewed/wait-merge from ${pr.title} (#${pr.number})`);
+    console.info(`Removed ${label} from "${pr.title}" (#${pr.number})`);
   } else {
     console.error(
-      `Failed to remove reviewed/wait-merge from ${pr.title} (#${pr.number})`,
+      `Failed to remove ${label} from "${pr.title}" (#${pr.number})`,
     );
     console.error(await response.text());
   }
+};
+
+const removeLabelsFromMergedPr = (labels: string[]) => {
+  return Promise.all(labels.map(async (label) => {
+    const prsThatAreMergedAndHaveTheLabel = await fetchMergedWithLabel(label);
+    return Promise.all(
+      prsThatAreMergedAndHaveTheLabel.items.map(
+        (pr: { title: string; number: number }) =>
+          removeLabelFromMergedPr(pr, label),
+      ),
+    );
+  }));
 };

--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -1,5 +1,6 @@
 import { serve } from "https://deno.land/std@0.182.0/http/server.ts";
-import { run } from "./backport.ts";
+import * as backport from "./backport.ts";
+import * as labels from "./labels.ts";
 
 if (
   Deno.env.get("BACKPORTER_GITEA_FORK") === undefined ||
@@ -12,8 +13,11 @@ if (
 
 serve((req: Request) => {
   if (req.url.endsWith("/trigger")) {
-    run();
-    return Response.json({ message: "Triggered backport" });
+    backport.run();
+    labels.run();
+    return Response.json({
+      message: "Triggered backport and label maintenance",
+    });
   } else {
     return Response.json({ status: "OK" });
   }


### PR DESCRIPTION
Closes #26

When PRs are merged there's no need for them to still have the `reviewed/wait-merge`/`reviewed/prioritize-merge` label.

Even though this codebase was originally intended to only handle backports, the foundations are laid to allow for label maintenance.