### PR TITLE
Remove `backport/*` labels from PRs targeting release branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ original pull request.
 The script will also look for merged pull requests that have the labels
 `reviewed/wait-merge` or `reviewed/prioritize-merge` and remove them.
 
+It will also search for pull requests that target release branches and remove
+any `backport/*` labels from them.
+
 ### Merge queue synchronization
 
 The script will also look for pull requests that have the label

--- a/src/backport.ts
+++ b/src/backport.ts
@@ -1,5 +1,5 @@
 import { cherryPickPr, initializeGitRepo } from "./git.ts";
-import { GiteaVersion } from "./giteaVersion.ts";
+import { fetchGiteaVersions, GiteaVersion } from "./giteaVersion.ts";
 import {
   addLabels,
   addPrComment,
@@ -8,16 +8,12 @@ import {
   fetchCandidates,
   fetchCurrentUser,
   fetchPr,
-  getMilestones,
 } from "./github.ts";
 
 export const run = async () => {
   const user = await fetchCurrentUser();
   await initializeGitRepo(user.login, user.email);
-  const milestones = await getMilestones();
-  for (const milestone of milestones) {
-    console.log(`Processing milestone ${milestone.title}`);
-    const giteaVersion = new GiteaVersion(milestone);
+  for (const giteaVersion of await fetchGiteaVersions()) {
     const candidates = await fetchCandidates(giteaVersion.majorMinorVersion);
     for (const candidate of candidates.items) {
       console.log("Parsing #" + candidate.number);

--- a/src/giteaVersion.ts
+++ b/src/giteaVersion.ts
@@ -1,4 +1,5 @@
 import { SemVer } from "https://deno.land/std@0.183.0/semver/mod.ts";
+import { getMilestones } from "./github.ts";
 
 export class GiteaVersion {
   majorMinorVersion: string;
@@ -10,3 +11,9 @@ export class GiteaVersion {
     this.milestoneNumber = milestone.number;
   }
 }
+
+// returns all gitea versions from the gitea repository milestones
+export const fetchGiteaVersions = async (): Promise<GiteaVersion[]> => {
+  const milestones = await getMilestones();
+  return milestones.map((milestone) => new GiteaVersion(milestone));
+};

--- a/src/github.ts
+++ b/src/github.ts
@@ -56,6 +56,19 @@ export const fetchPendingMerge = async () => {
   return json;
 };
 
+// returns a list of PRs that target the given branch
+export const fetchTargeting = async (branch: string) => {
+  const response = await fetch(
+    `${GITHUB_API}/search/issues?q=` +
+      encodeURIComponent(
+        `is:pr base:${branch} repo:go-gitea/gitea`,
+      ),
+    { headers: HEADERS },
+  );
+  const json = await response.json();
+  return json;
+};
+
 // update a given PR with the latest upstream changes by merging HEAD from
 // the base branch into the pull request branch
 export const updatePr = async (prNumber: number): Promise<Response> => {
@@ -108,7 +121,7 @@ export const backportPrExists = async (
   return json.total_count > 0;
 };
 
-type Milestone = { title: string };
+type Milestone = { title: string; number: number };
 
 // get Gitea milestones
 export const getMilestones = async (): Promise<Milestone[]> => {

--- a/src/labels.ts
+++ b/src/labels.ts
@@ -53,7 +53,7 @@ export const removeBackportLabelsFromPrsTargetingReleaseBranches = async () => {
 
 // given a list of PRs, removes the backport/* labels from them
 export const removeBackportLabelsFromPrs = (prs) => {
-  const promises = prs.flatMap((pr: {
+  return Promise.all(prs.flatMap((pr: {
     title;
     labels;
     number: number;
@@ -75,7 +75,5 @@ export const removeBackportLabelsFromPrs = (prs) => {
         console.error(await response.text());
       }
     });
-  });
-
-  return Promise.all(promises);
+  }));
 };

--- a/src/labels.ts
+++ b/src/labels.ts
@@ -1,11 +1,15 @@
-import { fetchMergedWithLabel, removeLabel } from "./github.ts";
+import { fetchMergedWithLabel, fetchTargeting, removeLabel } from "./github.ts";
+import { fetchGiteaVersions } from "./giteaVersion.ts";
 
 export const run = async () => {
   const labelsToRemoveAfterMerge = [
     "reviewed/wait-merge",
     "reviewed/prioritize-merge",
   ];
-  await removeLabelsFromMergedPr(labelsToRemoveAfterMerge);
+  await Promise.all([
+    removeLabelsFromMergedPr(labelsToRemoveAfterMerge),
+    removeBackportLabelsFromPrsTargetingReleaseBranches(),
+  ]);
 };
 
 const removeLabelFromMergedPr = async (
@@ -33,4 +37,46 @@ const removeLabelsFromMergedPr = (labels: string[]) => {
       ),
     );
   }));
+};
+
+// for each gitea version, fetch all PRs that target that version and remove the
+// backport/* labels from them
+export const removeBackportLabelsFromPrsTargetingReleaseBranches = async () => {
+  const giteaVersions = await fetchGiteaVersions();
+  // versions
+  return Promise.all(giteaVersions.map(async (version) => {
+    const prs = await fetchTargeting(`release/v${version.majorMinorVersion}`);
+    // PRs
+    return removeBackportLabelsFromPrs(prs.items);
+  }));
+};
+
+// given a list of PRs, removes the backport/* labels from them
+export const removeBackportLabelsFromPrs = (prs) => {
+  return Promise.all(
+    prs.map((pr: {
+      title;
+      labels;
+      number: number;
+    }) =>
+      // labels
+      Promise.all(
+        pr.labels.filter((label: { name: string }) =>
+          label.name.startsWith("backport/")
+        ).map(async (label: { name: string }) => {
+          const response = await removeLabel(pr.number, label.name);
+          if (response.ok) {
+            console.info(
+              `Removed ${label.name} from "${pr.title}" (#${pr.number})`,
+            );
+          } else {
+            console.error(
+              `Failed to remove ${label.name} from "${pr.title}" (#${pr.number})`,
+            );
+            console.error(await response.text());
+          }
+        }),
+      )
+    ),
+  );
 };


### PR DESCRIPTION
The script now removes all `backport/*` labels from pull requests that target release branches. The `giteaVersion` class now fetches milestones from the GitHub API for each gitea version. Finally, a `fetchTargeting` function queries the GitHub API for pull requests that target a specific branch.