### PR TITLE
Allow to trigger on events other than `push` and secure the webhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ deno run --allow-net --allow-env --allow-run src/webhook.ts
 ```
 
 This will spin up a web server on port 8000. You can then set up a GitHub
-webhook on `/trigger` to run the this bot.
+webhook on `/trigger` to run this bot.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Set the following environment variables:
 
 ```
 BACKPORTER_GITHUB_TOKEN= # A GitHub personal access token with permissions to add labels to the go-gitea/gitea repo
+BACKPORTER_GITHUB_SECRET= # The secret that is used to sign the webhook payload (set in GitHub's webhook settings)
 BACKPORTER_GITEA_FORK= # The fork of go-gitea/gitea to push the backport branch to (e.g. yardenshoham/gitea)
 ```
 
@@ -46,8 +47,8 @@ Then run:
 deno run --allow-net --allow-env --allow-run src/webhook.ts
 ```
 
-This will spin up a web server on port 8000. You can then set up a webhook on
-`/trigger` to run the automatic backport.
+This will spin up a web server on port 8000. You can then set up a GitHub
+webhook on `/trigger` to run the this bot.
 
 ## Contributing
 

--- a/src/labels.ts
+++ b/src/labels.ts
@@ -1,6 +1,13 @@
 import { fetchMergedWithLabel, fetchTargeting, removeLabel } from "./github.ts";
 import { fetchGiteaVersions } from "./giteaVersion.ts";
 
+// a relevant label is one that is used to control the merge queue,
+// manage backports or any other label that causes the bot to act on
+// detection, such as reviewed/* or backport/*
+export const isRelevantLabel = (label: string): boolean => {
+  return label.startsWith("reviewed/") || label.startsWith("backport/");
+};
+
 export const run = async () => {
   const labelsToRemoveAfterMerge = [
     "reviewed/wait-merge",

--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -1,26 +1,73 @@
 import { serve } from "https://deno.land/std@0.184.0/http/server.ts";
+import { createEventHandler } from "https://esm.sh/@octokit/webhooks@11.0.0";
+import { verify } from "https://esm.sh/@octokit/webhooks-methods@3.0.2";
 import * as backport from "./backport.ts";
 import * as labels from "./labels.ts";
 import * as mergeQueue from "./mergeQueue.ts";
 
+const secret = Deno.env.get("BACKPORTER_GITHUB_SECRET");
+
 if (
   Deno.env.get("BACKPORTER_GITEA_FORK") === undefined ||
-  Deno.env.get("BACKPORTER_GITHUB_TOKEN") === undefined
+  Deno.env.get("BACKPORTER_GITHUB_TOKEN") === undefined ||
+  secret
 ) {
   console.error(
-    "BACKPORTER_GITEA_FORK and BACKPORTER_GITHUB_TOKEN must be set",
+    "BACKPORTER_GITEA_FORK, BACKPORTER_GITHUB_TOKEN and BACKPORTER_GITHUB_SECRET must be set",
   );
 }
 
-serve((req: Request) => {
-  if (req.url.endsWith("/trigger")) {
+const webhook = createEventHandler({});
+
+webhook.on("push", ({ payload }) => {
+  // on push to main, backport (we have to be careful here as we cherry-pick and
+  // only have one local git repo)
+  if (payload.ref === "refs/heads/main") {
     backport.run();
-    labels.run();
-    mergeQueue.run();
-    return Response.json({
-      message:
-        "Triggered backport, label maintenance, and merge queue PRs sync",
-    });
+  }
+
+  // we should take this opportunity to run the label and merge queue maintenance
+  labels.run();
+  mergeQueue.run();
+});
+
+// on pull request labeling events, run the label and merge queue maintenance
+webhook.on(
+  ["pull_request.labeled", "pull_request.unlabeled"],
+  ({ payload }) => {
+    // these events are very common, so we only run the label and merge queue if
+    // the label is relevant
+    if (labels.isRelevantLabel(payload.label.name)) {
+      labels.run();
+      mergeQueue.run();
+    }
+  },
+);
+
+serve(async (req: Request) => {
+  if (req.url.endsWith("/trigger") && req.method === "POST") {
+    // verify signature
+    const requestBody = await req.text();
+    const signature = req.headers.get("x-hub-signature-256");
+    if (!signature) {
+      return Response.json({ message: "Missing signature" }, { status: 400 });
+    }
+    const verified = await verify(secret!, requestBody, signature);
+    if (!verified) {
+      return Response.json({ message: "Invalid signature" }, { status: 400 });
+    }
+
+    // parse webhook
+    const id = req.headers.get("x-github-delivery");
+    const name = req.headers.get("x-github-event");
+    if (!id || !name) {
+      return Response.json({ message: "Invalid GitHub webhook" }, {
+        status: 400,
+      });
+    }
+    webhook.receive({ id, name, payload: JSON.parse(requestBody) });
+
+    return Response.json({ message: "Webhook received" });
   } else {
     return Response.json({ status: "OK" });
   }

--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -45,6 +45,10 @@ webhook.on(
 );
 
 serve(async (req: Request) => {
+  // the request URL contain the entire URL, we want to trigger only if the
+  // URL ends with /trigger. If it has anything else (including a query string)
+  // we won't trigger. The GitHub webhook is set such that requests from it end
+  // with /trigger.
   if (req.url.endsWith("/trigger") && req.method === "POST") {
     // verify signature
     const requestBody = await req.text();


### PR DESCRIPTION
This makes the bot more flexible and responsive. We'll run backports only on `push` events to `main`.

Label maintenance and merge queue maintenance will be not only triggered only on `push` events but also on pull requests label events. To make sure we don't do too much unnecessary work, we only trigger these when either a `reviewed` or a `backport` label has been applied.

A new environment variable is introduced, `BACKPORTER_GITHUB_SECRET`. It'll be used to verify the requests are sent from GitHub.

- Closes #9 
- Part 1 of #38 (this change is required for that)

An octokit dependency is introduced for webhooks, we can later use the octokit SDK to query GitHub.