### PR TITLE
Don't sync PRs pending merge if they are already synced

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -81,6 +81,22 @@ export const updatePr = async (prNumber: number): Promise<Response> => {
   return response;
 };
 
+// get the go-gitea/gitea main branch
+export const fetchMain = async () => {
+  const response = await fetch(
+    `${GITHUB_API}/repos/go-gitea/gitea/branches/main`,
+    { headers: HEADERS },
+  );
+  return response.json();
+};
+
+// checks if the given PR needs to be updated
+export const needsUpdate = async (prNumber: number) => {
+  // get the PR and check if its base sha is the same as the current main sha
+  const [pr, main] = await Promise.all([fetchPr(prNumber), fetchMain()]);
+  return pr.base.sha !== main.commit.sha;
+};
+
 // given a PR number that has the given label, remove the label
 export const removeLabel = async (
   prNumber: number,

--- a/src/github_test.ts
+++ b/src/github_test.ts
@@ -1,5 +1,5 @@
 import { assertEquals } from "https://deno.land/std@0.184.0/testing/asserts.ts";
-import { getPrApprovers } from "./github.ts";
+import { fetchMain, getPrApprovers } from "./github.ts";
 
 Deno.test("getPrApprovers() returns the appropriate approvers", async () => {
   const prToApprovers = {
@@ -11,5 +11,15 @@ Deno.test("getPrApprovers() returns the appropriate approvers", async () => {
     Object.entries(prToApprovers).map(async ([pr, approvers]) => {
       assertEquals(await getPrApprovers(Number(pr)), approvers);
     }),
+  );
+});
+
+Deno.test("fetchMain() returns the appropriate main branch", async () => {
+  const mainBranch = await fetchMain();
+  assertEquals(mainBranch.name, "main");
+  assertEquals(mainBranch.protected, true);
+  assertEquals(
+    mainBranch._links.html,
+    "https://github.com/go-gitea/gitea/tree/main",
   );
 });

--- a/src/mergeQueue.ts
+++ b/src/mergeQueue.ts
@@ -1,25 +1,29 @@
-import { fetchPendingMerge, updatePr } from "./github.ts";
+import { fetchPendingMerge, needsUpdate, updatePr } from "./github.ts";
 export const run = async () => {
   // fetch all PRs that are pending merge
   const pendingMerge = await fetchPendingMerge();
 
-  // take the first PR in each milestone
-  const milestoneToPr = new Map();
-  for (const pr of pendingMerge.items) {
-    if (!milestoneToPr.has(pr.milestone.title)) {
-      milestoneToPr.set(pr.milestone.title, pr);
-    }
+  // group PRs by milestone
+  const milestoneToPr = new Map<string, number[]>();
+  for (const pr of pendingMerge) {
+    const milestone = pr.milestone?.title;
+    const prs = milestoneToPr.get(milestone) ?? [];
+    prs.push(pr.number);
+    milestoneToPr.set(milestone, prs);
   }
 
-  // update the PRs
-  const prs = Array.from(milestoneToPr.values());
-  return Promise.all(prs.map(async (pr: { number: number }) => {
-    const response = await updatePr(pr.number);
-    if (response.ok) {
-      console.info(`Synced PR #${pr.number} in merge queue`);
-    } else {
-      console.error(`Failed to sync PR #${pr.number} in merge queue`);
-      console.error(await response.text());
+  // for each milestone, try to update the lowest PR number (only if it needs an update), if it fails, try the next one
+  for (const [_, prs] of milestoneToPr) {
+    for (const pr of prs) {
+      if (!await needsUpdate(pr)) break;
+      const response = await updatePr(pr);
+      if (response.ok) {
+        console.info(`Synced PR #${pr} in merge queue`);
+        break;
+      } else {
+        console.error(`Failed to sync PR #${pr} in merge queue`);
+        console.error(await response.text());
+      }
     }
-  }));
+  }
 };


### PR DESCRIPTION
We now check if we need to update a PR and only do so if it's not synchronized already.

When the bot was triggered only on `push` this was unnecessary because all PRs became unsynchronized on `push`.