### PR TITLE
Assign milestones to pull requests upon creation based on target branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ The script will also look for pull requests that have the label
 `reviewed/wait-merge` and are still open. It will merge the upstream changes
 into the pull request head branch.
 
+### Milestone maintenance
+
+When a pull request is created, the script will assign it a milestone based on
+its target branch.
+
 ## Usage
 
 Set the following environment variables:

--- a/src/github.ts
+++ b/src/github.ts
@@ -118,6 +118,18 @@ export const fetchPr = async (prNumber: number) => {
   return response.json();
 };
 
+// sets the milestone of the given PR
+export const setMilestone = (prNumber: number, milestone: number) => {
+  return fetch(
+    `${GITHUB_API}/repos/go-gitea/gitea/issues/${prNumber}`,
+    {
+      method: "PATCH",
+      headers: HEADERS,
+      body: JSON.stringify({ milestone }),
+    },
+  );
+};
+
 // returns true if a backport PR exists for the given PR number and Gitea version
 export const backportPrExists = async (
   pr: { number: number },
@@ -229,18 +241,6 @@ export const createBackportPr = async (
       method: "POST",
       headers: HEADERS,
       body: JSON.stringify({ labels }),
-    },
-  );
-
-  // set milestone
-  await fetch(
-    `${GITHUB_API}/repos/go-gitea/gitea/issues/${json.number}`,
-    {
-      method: "PATCH",
-      headers: HEADERS,
-      body: JSON.stringify({
-        milestone: giteaVersion.milestoneNumber,
-      }),
     },
   );
 

--- a/src/milestones.ts
+++ b/src/milestones.ts
@@ -1,0 +1,49 @@
+import * as SemVer from "https://deno.land/std@0.184.0/semver/mod.ts";
+import { fetchGiteaVersions } from "./giteaVersion.ts";
+import * as github from "./github.ts";
+
+// given a PR number, set the milestone of the PR according to its base branch
+export const assign = async (prNumber: number) => {
+  // fetch the PR and current gitea versions
+  const [pr, giteaVersions] = await Promise.all([
+    github.fetchPr(prNumber),
+    fetchGiteaVersions(),
+  ]);
+
+  // find the gitea version that matches the PR's base branch
+  let giteaVersion = giteaVersions.find((version) =>
+    pr.base.ref === `release/v${version.majorMinorVersion}`
+  );
+
+  // if no gitea version is found, the PR is targeting the main branch. We
+  // will use the gitea version with the highest major and minor version using
+  // Deno's semver library (gt function)
+  if (!giteaVersion) {
+    giteaVersion = giteaVersions.reduce((highest, version) => {
+      if (
+        SemVer.gt(
+          `${version.majorMinorVersion}.0`,
+          `${highest.majorMinorVersion}.0`,
+        )
+      ) {
+        return version;
+      }
+      return highest;
+    }, giteaVersions[0]);
+  }
+
+  const response = await github.setMilestone(
+    prNumber,
+    giteaVersion!.milestoneNumber,
+  );
+  if (!response.ok) {
+    console.error(
+      `Failed to set milestone ${giteaVersion.majorMinorVersion} for PR #${prNumber}`,
+    );
+    console.error(await response.text());
+    return;
+  }
+  console.log(
+    `Set milestone ${giteaVersion.majorMinorVersion} for PR #${prNumber}`,
+  );
+};

--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -4,6 +4,7 @@ import { verify } from "https://esm.sh/@octokit/webhooks-methods@3.0.2";
 import * as backport from "./backport.ts";
 import * as labels from "./labels.ts";
 import * as mergeQueue from "./mergeQueue.ts";
+import * as milestones from "./milestones.ts";
 
 const secret = Deno.env.get("BACKPORTER_GITHUB_SECRET");
 
@@ -43,6 +44,12 @@ webhook.on(
     }
   },
 );
+
+// on pull request creation, we'll automatically set the milestone
+// according to the target branch
+webhook.on("pull_request.opened", ({ payload }) => {
+  milestones.assign(payload.pull_request.number);
+});
 
 serve(async (req: Request) => {
   // the request URL contain the entire URL, we want to trigger only if the


### PR DESCRIPTION
This change adds a new feature where created pull requests will be assigned a milestone based on their target branch.

- Closes #38