### PR TITLE
Filter out labels from the pull-request-size bot when creating a backport

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .env
 gitea/
+
+# used for local testing
+/debug.ts

--- a/src/github.ts
+++ b/src/github.ts
@@ -211,14 +211,15 @@ export const createBackportPr = async (
   });
   const json = await response.json();
 
-  // filter lgtm/*, backport/* and reviewed/* labels
+  // filter lgtm/*, backport/*, reviewed/*, and size/* labels
   const labels = originalPr.labels
     .map((label) => label.name)
     .filter((label) => {
       return (
         !label.startsWith("lgtm/") &&
         !label.startsWith("backport/") &&
-        !label.startsWith("reviewed/")
+        !label.startsWith("reviewed/") &&
+        !label.startsWith("size/")
       );
     });
 


### PR DESCRIPTION
Also added a file to gitignore that I heavily use for local testing