### PR TITLE
Fix unnecessary branch updates to backport PRs

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -81,10 +81,10 @@ export const updatePr = async (prNumber: number): Promise<Response> => {
   return response;
 };
 
-// get the go-gitea/gitea main branch
-export const fetchMain = async () => {
+// get a go-gitea/gitea branch
+export const fetchBranch = async (branch: string) => {
   const response = await fetch(
-    `${GITHUB_API}/repos/go-gitea/gitea/branches/main`,
+    `${GITHUB_API}/repos/go-gitea/gitea/branches/${branch}`,
     { headers: HEADERS },
   );
   return response.json();
@@ -92,9 +92,10 @@ export const fetchMain = async () => {
 
 // checks if the given PR needs to be updated
 export const needsUpdate = async (prNumber: number) => {
-  // get the PR and check if its base sha is the same as the current main sha
-  const [pr, main] = await Promise.all([fetchPr(prNumber), fetchMain()]);
-  return pr.base.sha !== main.commit.sha;
+  // get the PR and check if its base sha is the same as its base branch
+  const pr = await fetchPr(prNumber);
+  const base = await fetchBranch(pr.base.ref);
+  return pr.base.sha !== base.commit.sha;
 };
 
 // given a PR number that has the given label, remove the label

--- a/src/github_test.ts
+++ b/src/github_test.ts
@@ -1,5 +1,5 @@
 import { assertEquals } from "https://deno.land/std@0.184.0/testing/asserts.ts";
-import { fetchMain, getPrApprovers } from "./github.ts";
+import { fetchBranch, getPrApprovers } from "./github.ts";
 
 Deno.test("getPrApprovers() returns the appropriate approvers", async () => {
   const prToApprovers = {
@@ -14,12 +14,31 @@ Deno.test("getPrApprovers() returns the appropriate approvers", async () => {
   );
 });
 
-Deno.test("fetchMain() returns the appropriate main branch", async () => {
-  const mainBranch = await fetchMain();
+Deno.test('fetchBranch("main") returns the appropriate main branch', async () => {
+  const mainBranch = await fetchBranch("main");
   assertEquals(mainBranch.name, "main");
   assertEquals(mainBranch.protected, true);
   assertEquals(
     mainBranch._links.html,
     "https://github.com/go-gitea/gitea/tree/main",
+  );
+});
+
+Deno.test("fetchBranch() handles full ref name well", async () => {
+  const [mainBranch, releaseV119Branch] = await Promise.all([
+    fetchBranch("refs/heads/main"),
+    fetchBranch("refs/heads/release/v1.19"),
+  ]);
+  assertEquals(mainBranch.name, "main");
+  assertEquals(mainBranch.protected, true);
+  assertEquals(
+    mainBranch._links.html,
+    "https://github.com/go-gitea/gitea/tree/main",
+  );
+  assertEquals(releaseV119Branch.name, "release/v1.19");
+  assertEquals(releaseV119Branch.protected, true);
+  assertEquals(
+    releaseV119Branch._links.html,
+    "https://github.com/go-gitea/gitea/tree/release/v1.19",
   );
 });


### PR DESCRIPTION
The code assumed all PRs target the main branch. It now checks if each PR is synced against its base branch, not against the main branch.