### PR TITLE
Remove PRs with merge conflicts from the merge queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ any `backport/*` labels from them.
 
 The script will also look for pull requests that have the label
 `reviewed/wait-merge` and are still open. It will merge the upstream changes
-into the pull request head branch.
+into the pull request head branch. If a merge conflict occurs, it will remove
+the pull request from the merge queue.
 
 ### Milestone maintenance
 

--- a/src/mergeQueue.ts
+++ b/src/mergeQueue.ts
@@ -10,19 +10,22 @@ export const run = async () => {
   const pendingMerge = await fetchPendingMerge();
 
   // group PRs by milestone
-  const milestoneToPr = new Map<string, number[]>();
+  const milestoneToPr = new Map<
+    string,
+    { number: number; user: { login: string } }[]
+  >();
   for (const pr of pendingMerge.items) {
     const milestone = pr.milestone?.title;
     const prs = milestoneToPr.get(milestone) ?? [];
-    prs.push(pr.number);
+    prs.push(pr);
     milestoneToPr.set(milestone, prs);
   }
 
   // for each milestone, try to update the lowest PR number (only if it needs an update), if it fails, try the next one
   for (const [_, prs] of milestoneToPr) {
     for (const pr of prs) {
-      if (!await needsUpdate(pr)) break;
-      const response = await updatePr(pr);
+      if (!await needsUpdate(pr.number)) break;
+      const response = await updatePr(pr.number);
       if (response.ok) {
         console.info(`Synced PR #${pr} in merge queue`);
         break;
@@ -37,8 +40,11 @@ export const run = async () => {
       console.info(`Merge conflict detected in PR #${pr} in merge queue`);
       // if there is a merge conflict, we'll add a comment to fix the conflicts and remove the reviewed/wait-merge label
       await Promise.all([
-        addPrComment(pr, "Please fix the merge conflicts. :tea:"),
-        removeLabel(pr, "reviewed/wait-merge"),
+        addPrComment(
+          pr.number,
+          `@${pr.user.login} please fix the merge conflicts. :tea:`,
+        ),
+        removeLabel(pr.number, "reviewed/wait-merge"),
       ]);
     }
   }


### PR DESCRIPTION
If, when updating PRs before merge, a merge conflict is detected, add a comment about it and remove the `reviewed/wait-merge` label from the PR.