### PR TITLE
Replace LGTM bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ When a pull request is created, the script will assign it a milestone based on
 its target branch. The script makes sure that unmerged closed pull requests are
 not included in any milestone.
 
+### LGTM
+
+The script will maintain each pull request's LGTM count. It will add the
+appropriate label (one of `lgtm/need 2`, `lgtm/need 1`, or `lgtm/done`) based on
+the number of approvals the pull request has. It will also set the commit status
+to `success` if the pull request has 2 or more approvals (`pending` if not).
+
 ## Usage
 
 Set the following environment variables:

--- a/src/github.ts
+++ b/src/github.ts
@@ -81,6 +81,72 @@ export const updatePr = async (prNumber: number): Promise<Response> => {
   return response;
 };
 
+// sets a commit status
+export const setCommitStatus = (
+  sha: string,
+  state: "error" | "failure" | "pending" | "success",
+  description: string,
+) => {
+  // TODO go-gitea/gitea
+  return fetch(
+    `${GITHUB_API}/repos/yardenshoham/test/statuses/${sha}`,
+    {
+      method: "POST",
+      headers: HEADERS,
+      body: JSON.stringify({
+        state,
+        context: "backporter/lgtm",
+        description,
+      }),
+    },
+  );
+};
+
+// returns the number of approvals a PR has
+export const getPrApprovalNumber = async (
+  prNumber: number,
+): Promise<number> => {
+  // load all reviews
+  const reviews: {
+    state:
+      | "APPROVED"
+      | "CHANGES_REQUESTED"
+      | "COMMENTED"
+      | "DISMISSED"
+      | "PENDING";
+    user: { login: string };
+  }[] = [];
+  let page = 1;
+  while (true) {
+    const response = await fetch(
+      `${GITHUB_API}/repos/go-gitea/gitea/pulls/${prNumber}/reviews?per_page=100&page=${page}`,
+      { headers: HEADERS },
+    );
+    if (!response.ok) throw new Error(await response.text());
+    const results: [] = await response.json();
+    if (results.length === 0) break;
+    reviews.push(...results);
+    page++;
+  }
+
+  // count approvers by replaying all reviews (they are already sorted)
+  const approvers = new Set();
+  for (const review of reviews) {
+    switch (review.state) {
+      case "APPROVED":
+        approvers.add(review.user.login);
+        break;
+      case "DISMISSED":
+      case "CHANGES_REQUESTED":
+        approvers.delete(review.user.login);
+        break;
+      default:
+        break;
+    }
+  }
+  return approvers.size;
+};
+
 // get the go-gitea/gitea main branch
 export const fetchMain = async () => {
   const response = await fetch(

--- a/src/github.ts
+++ b/src/github.ts
@@ -102,9 +102,8 @@ export const setCommitStatus = (
   state: "error" | "failure" | "pending" | "success",
   description: string,
 ) => {
-  // TODO go-gitea/gitea
   return fetch(
-    `${GITHUB_API}/repos/yardenshoham/test/statuses/${sha}`,
+    `${GITHUB_API}/repos/go-gitea/gitea/statuses/${sha}`,
     {
       method: "POST",
       headers: HEADERS,

--- a/src/github_test.ts
+++ b/src/github_test.ts
@@ -16,7 +16,7 @@ Deno.test("getPrApprovers() returns the appropriate approvers", async () => {
 
 Deno.test("getPrApprovalNumber() returns the appropriate approval number", async () => {
   const prToNumber = {
-    24270: 2,
+    24270: 3,
     24254: 2,
     24259: 2,
     24055: 0,

--- a/src/github_test.ts
+++ b/src/github_test.ts
@@ -1,5 +1,5 @@
 import { assertEquals } from "https://deno.land/std@0.184.0/testing/asserts.ts";
-import { fetchMain, getPrApprovers } from "./github.ts";
+import { fetchMain, getPrApprovalNumber, getPrApprovers } from "./github.ts";
 
 Deno.test("getPrApprovers() returns the appropriate approvers", async () => {
   const prToApprovers = {
@@ -10,6 +10,20 @@ Deno.test("getPrApprovers() returns the appropriate approvers", async () => {
   await Promise.all(
     Object.entries(prToApprovers).map(async ([pr, approvers]) => {
       assertEquals(await getPrApprovers(Number(pr)), approvers);
+    }),
+  );
+});
+
+Deno.test("getPrApprovalNumber() returns the appropriate approval number", async () => {
+  const prToNumber = {
+    24270: 2,
+    24254: 2,
+    24259: 2,
+    24055: 0,
+  };
+  await Promise.all(
+    Object.entries(prToNumber).map(async ([pr, number]) => {
+      assertEquals(await getPrApprovalNumber(Number(pr)), number);
     }),
   );
 });

--- a/src/lgtm.ts
+++ b/src/lgtm.ts
@@ -5,9 +5,10 @@ import {
   setCommitStatus,
 } from "./github.ts";
 
-// given a pr number, set its lgtm status check
-export const setPrStatus = async (
+// given a pr number, set its lgtm status check and lgtm label
+export const setPrStatusAndLabel = async (
   pr: {
+    labels: { name: string }[];
     head: { sha: string };
     title: string;
     number: number;
@@ -21,48 +22,10 @@ export const setPrStatus = async (
     return;
   }
 
-  let message = "Needs two more approvals";
-  let state: "pending" | "success" = "pending";
-  if (approvals === 1) message = "Needs one more approval";
-  if (approvals >= 2) {
-    message = "Approved";
-    state = "success";
-  }
-
-  const response = await setCommitStatus(pr.head.sha, state, message);
-  if (response.ok) {
-    console.info(
-      `Set commit status in "${pr.title}" (#${pr.number})`,
-    );
-  } else {
-    console.error(
-      `Failed to set commit status in  "${pr.title}" (#${pr.number})`,
-    );
-    console.error(await response.text());
-  }
-};
-
-// given a pr, set its lgtm label
-export const setPrLabel = async (pr: {
-  labels: { name: string }[];
-  head: { sha: string };
-  title: string;
-  number: number;
-}) => {
-  let approvals;
-  try {
-    approvals = await getPrApprovalNumber(pr.number);
-  } catch (error) {
-    console.error(error);
-    return;
-  }
-
-  let desiredLabel = "lgtm/need 2";
-  if (approvals === 1) desiredLabel = "lgtm/need 1";
-  if (approvals >= 2) desiredLabel = "lgtm/done";
-
+  const { state, message, desiredLabel } = getPrStatusAndLabel(approvals);
   const currentLgtmLabels = pr.labels.filter((l) => l.name.startsWith("lgtm/"));
-  // remove any undesired labels
+
+  // remove any undesired lgtm labels
   await Promise.all(
     currentLgtmLabels.filter((l) => l.name !== desiredLabel).map(
       async (label) => {
@@ -85,4 +48,36 @@ export const setPrLabel = async (pr: {
   if (!currentLgtmLabels.some((label) => label.name === desiredLabel)) {
     await addLabels(pr.number, [desiredLabel]);
   }
+
+  // set commit status
+  const response = await setCommitStatus(pr.head.sha, state, message);
+  if (response.ok) {
+    console.info(
+      `Set commit status in "${pr.title}" (#${pr.number})`,
+    );
+  } else {
+    console.error(
+      `Failed to set commit status in  "${pr.title}" (#${pr.number})`,
+    );
+    console.error(await response.text());
+  }
+};
+
+// returns the status, message, and label for a given number of approvals
+export const getPrStatusAndLabel = (approvals: number) => {
+  let desiredLabel = "lgtm/need 2";
+  let message = "Needs two more approvals";
+  let state: "pending" | "success" = "pending";
+
+  if (approvals === 1) {
+    desiredLabel = "lgtm/need 1";
+    message = "Needs one more approval";
+  }
+  if (approvals >= 2) {
+    desiredLabel = "lgtm/done";
+    message = "Approved";
+    state = "success";
+  }
+
+  return { state, message, desiredLabel };
 };

--- a/src/lgtm.ts
+++ b/src/lgtm.ts
@@ -1,0 +1,88 @@
+import {
+  addLabels,
+  getPrApprovalNumber,
+  removeLabel,
+  setCommitStatus,
+} from "./github.ts";
+
+// given a pr number, set its lgtm status check
+export const setPrStatus = async (
+  pr: {
+    head: { sha: string };
+    title: string;
+    number: number;
+  },
+) => {
+  let approvals;
+  try {
+    approvals = await getPrApprovalNumber(pr.number);
+  } catch (error) {
+    console.error(error);
+    return;
+  }
+
+  let message = "Needs two more approvals";
+  let state: "pending" | "success" = "pending";
+  if (approvals === 1) message = "Needs one more approval";
+  if (approvals >= 2) {
+    message = "Approved";
+    state = "success";
+  }
+
+  const response = await setCommitStatus(pr.head.sha, state, message);
+  if (response.ok) {
+    console.info(
+      `Set commit status in "${pr.title}" (#${pr.number})`,
+    );
+  } else {
+    console.error(
+      `Failed to set commit status in  "${pr.title}" (#${pr.number})`,
+    );
+    console.error(await response.text());
+  }
+};
+
+// given a pr, set its lgtm label
+export const setPrLabel = async (pr: {
+  labels: { name: string }[];
+  head: { sha: string };
+  title: string;
+  number: number;
+}) => {
+  let approvals;
+  try {
+    approvals = await getPrApprovalNumber(pr.number);
+  } catch (error) {
+    console.error(error);
+    return;
+  }
+
+  let desiredLabel = "lgtm/need 2";
+  if (approvals === 1) desiredLabel = "lgtm/need 1";
+  if (approvals >= 2) desiredLabel = "lgtm/done";
+
+  const currentLgtmLabels = pr.labels.filter((l) => l.name.startsWith("lgtm/"));
+  // remove any undesired labels
+  await Promise.all(
+    currentLgtmLabels.filter((l) => l.name !== desiredLabel).map(
+      async (label) => {
+        const response = await removeLabel(pr.number, label.name);
+        if (response.ok) {
+          console.info(
+            `Removed ${label.name} from "${pr.title}" (#${pr.number})`,
+          );
+        } else {
+          console.error(
+            `Failed to remove ${label.name} from "${pr.title}" (#${pr.number})`,
+          );
+          console.error(await response.text());
+        }
+      },
+    ),
+  );
+
+  // add desired label if it's not there
+  if (!currentLgtmLabels.some((label) => label.name === desiredLabel)) {
+    await addLabels(pr.number, [desiredLabel]);
+  }
+};

--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -5,6 +5,7 @@ import * as backport from "./backport.ts";
 import * as labels from "./labels.ts";
 import * as mergeQueue from "./mergeQueue.ts";
 import * as milestones from "./milestones.ts";
+import * as lgtm from "./lgtm.ts";
 
 const secret = Deno.env.get("BACKPORTER_GITHUB_SECRET");
 
@@ -50,6 +51,15 @@ webhook.on(
 webhook.on("pull_request.opened", ({ payload }) => {
   milestones.assign(payload.pull_request.number);
 });
+
+// on pull request open, synchronization (push), and pull request review,
+// we'll update the lgtm status check and label
+webhook.on(
+  ["pull_request.opened", "pull_request.synchronize", "pull_request_review"],
+  ({ payload }) => {
+    lgtm.setPrStatusAndLabel(payload.pull_request);
+  },
+);
 
 // when PRs close, make sure no unmerged closed PRs have milestones
 webhook.on("pull_request.closed", () => {


### PR DESCRIPTION
This will do the same thing the LGTM bot did more or less. We won't parse the `MAINTAINERS` file nor look for comments containing the word LGTM.

This is experimental as I couldn't really test it. Before this is merged, the old LGTM bot must be stopped. After this is merged, the context `backporter/lgtm` must be added to `go-gitea/gitea`'s required status checks in all protected branches (and `approvals/lgtm` removed).
![image](https://user-images.githubusercontent.com/20454870/233852721-5d6950ca-f520-48d4-9144-bd80a08c0c53.png)

If the `BACKPORTER_GITHUB_TOKEN` used for production doesn't contain the `repo:status` scope, it must be added before merging.
![image](https://user-images.githubusercontent.com/20454870/233853011-bbf86efc-bbfb-413c-ae14-364a26297ee3.png)

- Closes #50