### PR TITLE
Stop old builds when a new commit is pushed in a PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ appropriate label (one of `lgtm/need 2`, `lgtm/need 1`, or `lgtm/done`) based on
 the number of approvals the pull request has. It will also set the commit status
 to `success` if the pull request has 2 or more approvals (`pending` if not).
 
+### Build maintenance
+
+The script will make sure no irrelevant builds are running. It will cancel any
+builds that have had new commits pushed to their branch.
+
 ## Usage
 
 Set the following environment variables:
@@ -53,6 +58,7 @@ Set the following environment variables:
 BACKPORTER_GITHUB_TOKEN= # A GitHub personal access token with permissions to add labels to the go-gitea/gitea repo
 BACKPORTER_GITHUB_SECRET= # The secret that is used to sign the webhook payload (set in GitHub's webhook settings)
 BACKPORTER_GITEA_FORK= # The fork of go-gitea/gitea to push the backport branch to (e.g. yardenshoham/gitea)
+BACKPORTER_DRONE_TOKEN= # A token for the Drone CI instance https://drone.gitea.io
 ```
 
 Then run:

--- a/src/builds.ts
+++ b/src/builds.ts
@@ -1,0 +1,22 @@
+import * as drone from "./drone.ts";
+
+// stops all builds currently running on the given pull request except the one
+// with the current head
+export const stopOldBuilds = async (
+  pr: { number: number; head: { sha: string } },
+): Promise<void> => {
+  const builds: {
+    status: string;
+    ref: string;
+    after: string;
+    number: number;
+  }[] = await drone.listBuilds();
+
+  await Promise.all(
+    builds.filter((build) =>
+      build.status === "running" &&
+      build.ref === `refs/pull/${pr.number}/head` &&
+      build.after !== pr.head.sha
+    ).map((build) => drone.deleteBuild(build.number)),
+  );
+};

--- a/src/builds.ts
+++ b/src/builds.ts
@@ -17,6 +17,6 @@ export const stopOldBuilds = async (
       build.status === "running" &&
       build.ref === `refs/pull/${pr.number}/head` &&
       build.after !== pr.head.sha
-    ).map((build) => drone.deleteBuild(build.number)),
+    ).map((build) => drone.stopBuild(build.number)),
   );
 };

--- a/src/drone.ts
+++ b/src/drone.ts
@@ -3,7 +3,7 @@ const HEADERS = {
   Authorization: `Bearer ${Deno.env.get("BACKPORTER_DRONE_TOKEN")}`,
 };
 
-export const deleteBuild = async (buildNumber: number): Promise<void> => {
+export const stopBuild = async (buildNumber: number): Promise<void> => {
   const response = await fetch(`${DRONE_API}/builds/${buildNumber}`, {
     method: "DELETE",
     headers: HEADERS,
@@ -11,7 +11,7 @@ export const deleteBuild = async (buildNumber: number): Promise<void> => {
 
   if (!response.ok) {
     throw new Error(
-      `Failed to delete build ${buildNumber}: ${response.statusText}`,
+      `Failed to stop build ${buildNumber}: ${response.statusText}`,
     );
   }
 };

--- a/src/drone.ts
+++ b/src/drone.ts
@@ -1,0 +1,30 @@
+const DRONE_API = "https://drone.gitea.io/api/repos/go-gitea/gitea";
+const HEADERS = {
+  Authorization: `Bearer ${Deno.env.get("BACKPORTER_DRONE_TOKEN")}`,
+};
+
+export const deleteBuild = async (buildNumber: number): Promise<void> => {
+  const response = await fetch(`${DRONE_API}/builds/${buildNumber}`, {
+    method: "DELETE",
+    headers: HEADERS,
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to delete build ${buildNumber}: ${response.statusText}`,
+    );
+  }
+};
+
+// list builds
+export const listBuilds = async (): Promise<[]> => {
+  const response = await fetch(`${DRONE_API}/builds`, {
+    headers: HEADERS,
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to list builds: ${response.statusText}`);
+  }
+
+  return await response.json();
+};


### PR DESCRIPTION
On each new commit, we'll cancel old builds that provide no value. This adds the mandatory `BACKPORTER_DRONE_TOKEN` environment variable.

Drone API references:
- Authentication: https://docs.drone.io/api/overview/
- Listing recent builds: https://docs.drone.io/api/builds/build_list/
- Stopping builds: https://docs.drone.io/api/builds/build_stop/

I manually tested this.

![image](https://user-images.githubusercontent.com/20454870/234107492-34cd4a55-7dd2-4d41-b40a-509cbd745355.png)
