### PR TITLE
Don't set the milestone automatically for PRs targeting `main`

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ the pull request from the merge queue.
 ### Milestone maintenance
 
 When a pull request is created, the script will assign it a milestone based on
-its target branch. The script makes sure that unmerged closed pull requests are
-not included in any milestone.
+its target branch (except pull requests targeting `main`). The script makes sure
+that unmerged closed pull requests are not included in any milestone.
 
 ### LGTM
 

--- a/src/milestones.ts
+++ b/src/milestones.ts
@@ -1,50 +1,35 @@
-import * as SemVer from "https://deno.land/std@0.184.0/semver/mod.ts";
 import { fetchGiteaVersions } from "./giteaVersion.ts";
 import * as github from "./github.ts";
 
 // given a PR number, set the milestone of the PR according to its base branch
-export const assign = async (prNumber: number) => {
-  // fetch the PR and current gitea versions
-  const [pr, giteaVersions] = await Promise.all([
-    github.fetchPr(prNumber),
-    fetchGiteaVersions(),
-  ]);
+export const assign = async (pr: { number: number; base: { ref: string } }) => {
+  // fetch the current gitea versions
+  const giteaVersions = await fetchGiteaVersions();
 
   // find the gitea version that matches the PR's base branch
-  let giteaVersion = giteaVersions.find((version) =>
+  const giteaVersion = giteaVersions.find((version) =>
     pr.base.ref === `release/v${version.majorMinorVersion}`
   );
 
   // if no gitea version is found, the PR is targeting the main branch. We
-  // will use the gitea version with the highest major and minor version using
-  // Deno's semver library (gt function)
+  // don't set a milestone automatically for PRs targeting the main branch.
   if (!giteaVersion) {
-    giteaVersion = giteaVersions.reduce((highest, version) => {
-      if (
-        SemVer.gt(
-          `${version.majorMinorVersion}.0`,
-          `${highest.majorMinorVersion}.0`,
-        )
-      ) {
-        return version;
-      }
-      return highest;
-    }, giteaVersions[0]);
+    return;
   }
 
   const response = await github.setMilestone(
-    prNumber,
+    pr.number,
     giteaVersion!.milestoneNumber,
   );
   if (!response.ok) {
     console.error(
-      `Failed to set milestone ${giteaVersion.majorMinorVersion} for PR #${prNumber}`,
+      `Failed to set milestone ${giteaVersion.majorMinorVersion} for PR #${pr.number}`,
     );
     console.error(await response.text());
     return;
   }
   console.log(
-    `Set milestone ${giteaVersion.majorMinorVersion} for PR #${prNumber}`,
+    `Set milestone ${giteaVersion.majorMinorVersion} for PR #${pr.number}`,
   );
 };
 

--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -49,7 +49,7 @@ webhook.on(
 // on pull request creation, we'll automatically set the milestone
 // according to the target branch
 webhook.on("pull_request.opened", ({ payload }) => {
-  milestones.assign(payload.pull_request.number);
+  milestones.assign(payload.pull_request);
 });
 
 // on pull request open, synchronization (push), and pull request review,


### PR DESCRIPTION
Following a discord maintainer poll.

Also refactor to get PR details from the webhook instead of an additional API call.