### PR TITLE
If a PR has no milestone when merged, automatically add it to a milestone

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ the pull request from the merge queue.
 ### Milestone maintenance
 
 When a pull request is created, the script will assign it a milestone based on
-its target branch (except pull requests targeting `main`). The script makes sure
-that unmerged closed pull requests are not included in any milestone.
+its target branch (except pull requests targeting `main`, we'll assign those on
+merge). The script makes sure that unmerged closed pull requests are not
+included in any milestone.
 
 ### LGTM
 

--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -47,9 +47,18 @@ webhook.on(
 );
 
 // on pull request creation, we'll automatically set the milestone
-// according to the target branch
+// according to the target branch (if it's a release branch)
 webhook.on("pull_request.opened", ({ payload }) => {
-  milestones.assign(payload.pull_request);
+  if (payload.pull_request.base.ref.startsWith("release/")) {
+    milestones.assign(payload.pull_request);
+  }
+});
+
+// on pull request merge, make sure the PR has a milestone
+webhook.on("pull_request.closed", ({ payload }) => {
+  if (payload.pull_request.merged && !payload.pull_request.milestone) {
+    milestones.assign(payload.pull_request);
+  }
 });
 
 // on pull request open, synchronization (push), and pull request review,


### PR DESCRIPTION
We'll automatically set milestone for pull requests targeting release branches on creation and all pull requests on merge.