### PR TITLE
Debounce label maintenance and reduce wait time for merge queue debounce

### DIFF
--- a/src/labels.ts
+++ b/src/labels.ts
@@ -1,5 +1,6 @@
 import { fetchMergedWithLabel, fetchTargeting, removeLabel } from "./github.ts";
 import { fetchGiteaVersions } from "./giteaVersion.ts";
+import { debounce } from "https://deno.land/std@0.184.0/async/mod.ts";
 
 // a relevant label is one that is used to control the merge queue,
 // manage backports or any other label that causes the bot to act on
@@ -8,7 +9,7 @@ export const isRelevantLabel = (label: string): boolean => {
   return label.startsWith("reviewed/") || label.startsWith("backport/");
 };
 
-export const run = async () => {
+const maintain = async () => {
   const labelsToRemoveAfterMerge = [
     "reviewed/wait-merge",
     "reviewed/prioritize-merge",
@@ -84,3 +85,6 @@ export const removeBackportLabelsFromPrs = (prs) => {
     });
   }));
 };
+
+// make sure we don't trigger too often
+export const run = debounce(maintain, 8000);

--- a/src/mergeQueue.ts
+++ b/src/mergeQueue.ts
@@ -42,4 +42,4 @@ const updateBranch = async () => {
 };
 
 // make sure we don't trigger too often
-export const run = debounce(updateBranch, 15000);
+export const run = debounce(updateBranch, 8000);


### PR DESCRIPTION
We sometimes trigger label maintenance too often, for example:
![image](https://user-images.githubusercontent.com/20454870/234414860-fa93230d-71f6-4bc5-a6d9-4bd67bbc5f19.png)
