### PR TITLE
Drop LGTM labels and count non-merger maintainers' review in GitHub's approval count

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -27,7 +27,7 @@ jobs:
         run: deno lint
 
       - name: Run tests
-        run: deno test -A
+        run: deno test -A --filter "tests that do not require authentication"
         env:
           BACKPORTER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BACKPORTER_GITEA_FORK: GiteaBot/gitea

--- a/README.md
+++ b/README.md
@@ -41,12 +41,8 @@ included in any milestone.
 
 ### LGTM
 
-The script will maintain each pull request's LGTM count. It will add the
-appropriate label (one of `lgtm/need 2`, `lgtm/need 1`, `lgtm/done`, or
-`lgtm/blocked`) based on the number of approvals (or change requests) the pull
-request has. It will also set the commit status to `success` if the pull request
-has 2 or more approvals without changes requested (`pending` if not or `failure`
-if changes are requested).
+The script will echo non-merger maintainer reviews so GitHub counts their
+approval.
 
 ## Usage
 

--- a/src/backport.ts
+++ b/src/backport.ts
@@ -6,23 +6,17 @@ import {
   backportPrExists,
   createBackportPr,
   fetchCandidates,
-  fetchCurrentUser,
   fetchPr,
 } from "./github.ts";
+import { bot } from "./user.ts";
 
-if (
-  !Deno.env.get("BACKPORTER_GITEA_FORK") ||
-  !Deno.env.get("BACKPORTER_GITHUB_TOKEN")
-) {
-  console.error(
-    "BACKPORTER_GITEA_FORK and BACKPORTER_GITHUB_TOKEN must be set",
-  );
-}
-
-const user = await fetchCurrentUser();
-await initializeGitRepo(user.login, user.email);
+let initialized = false;
 
 export const run = async () => {
+  if (!initialized) {
+    await initializeGitRepo(bot.login, bot.email);
+    initialized = true;
+  }
   for (const giteaVersion of await fetchGiteaVersions()) {
     const candidates = await fetchCandidates(giteaVersion.majorMinorVersion);
     for (const candidate of candidates.items) {

--- a/src/github_test.ts
+++ b/src/github_test.ts
@@ -1,87 +1,112 @@
-import { assertEquals } from "https://deno.land/std@0.186.0/testing/asserts.ts";
-import { fetchBranch, fetchPr, getPrReviewers } from "./github.ts";
+import {
+  assert,
+  assertEquals,
+  assertFalse,
+} from "https://deno.land/std@0.186.0/testing/asserts.ts";
+import {
+  fetchBranch,
+  fetchMaintainersExcludingMergers,
+  fetchPr,
+  getPrReviewers,
+} from "./github.ts";
+import { describe, it } from "https://deno.land/std@0.186.0/testing/bdd.ts";
 
-Deno.test("getPrReviewers() returns the appropriate approvers", async () => {
-  const prToApproversAndBlockers = {
-    8346: { // note lafriks and guillep2k are requested reviewers so they don't count as approvers nor blockers
-      approvers: new Set([
-        "silverwind",
-        "6543",
-        "lunny",
-        "techknowlogick",
-        "zeripath",
-        "sapk",
-        "BaxAndrei",
-      ]),
-      blockers: new Set(["SuperSandro2000"]),
-    },
-    23993: {
-      approvers: new Set(["delvh", "jolheiser"]),
-      blockers: new Set<string>(),
-    },
-    24051: {
-      approvers: new Set(["delvh", "silverwind"]),
-      blockers: new Set<string>(),
-    },
-    24047: {
-      approvers: new Set(["yardenshoham", "lunny"]),
-      blockers: new Set<string>(),
-    },
-    24055: { approvers: new Set<string>(), blockers: new Set<string>() },
-    24147: { // delvh approved and then self-requested review
-      approvers: new Set<string>(),
-      blockers: new Set<string>(),
-    },
-    24254: {
-      approvers: new Set(["jolheiser", "yardenshoham"]),
-      blockers: new Set<string>(),
-    },
-    24259: {
-      approvers: new Set(["jolheiser", "delvh"]),
-      blockers: new Set<string>(),
-    },
-    24270: {
-      approvers: new Set(["lunny", "delvh", "silverwind"]),
-      blockers: new Set<string>(),
-    },
-  };
-  await Promise.all(
-    Object.entries(prToApproversAndBlockers).map(
-      async ([prNumber, approversAndBlockers]) => {
-        const pr = await fetchPr(Number(prNumber));
-        const result = await getPrReviewers(pr);
-        assertEquals(result.approvers, approversAndBlockers.approvers);
-        assertEquals(result.blockers, approversAndBlockers.blockers);
+Deno.test("fetchMaintainersExcludingMergers() returns the appropriate maintainers", async () => {
+  const maintainers = await fetchMaintainersExcludingMergers();
+  // mergers
+  assertFalse(maintainers.has("lunny"));
+  assertFalse(maintainers.has("silverwind"));
+  assertFalse(maintainers.has("delvh"));
+
+  // maintainers
+  assert(maintainers.has("Zettat123"));
+  assert(maintainers.has("HesterG"));
+  assert(maintainers.has("sillyguodong"));
+});
+
+describe("tests that do not require authentication", () => {
+  it("getPrReviewers() returns the appropriate approvers", async () => {
+    const prToApproversAndBlockers = {
+      8346: { // note lafriks and guillep2k are requested reviewers so they don't count as approvers nor blockers
+        approvers: new Set([
+          "silverwind",
+          "6543",
+          "lunny",
+          "techknowlogick",
+          "zeripath",
+          "sapk",
+          "BaxAndrei",
+        ]),
+        blockers: new Set(["SuperSandro2000"]),
       },
-    ),
-  );
-});
+      23993: {
+        approvers: new Set(["delvh", "jolheiser"]),
+        blockers: new Set<string>(),
+      },
+      24051: {
+        approvers: new Set(["delvh", "silverwind"]),
+        blockers: new Set<string>(),
+      },
+      24047: {
+        approvers: new Set(["yardenshoham", "lunny"]),
+        blockers: new Set<string>(),
+      },
+      24055: { approvers: new Set<string>(), blockers: new Set<string>() },
+      24147: { // delvh approved and then self-requested review
+        approvers: new Set<string>(),
+        blockers: new Set<string>(),
+      },
+      24254: {
+        approvers: new Set(["jolheiser", "yardenshoham"]),
+        blockers: new Set<string>(),
+      },
+      24259: {
+        approvers: new Set(["jolheiser", "delvh"]),
+        blockers: new Set<string>(),
+      },
+      24270: {
+        approvers: new Set(["lunny", "delvh", "silverwind"]),
+        blockers: new Set<string>(),
+      },
+    };
+    await Promise.all(
+      Object.entries(prToApproversAndBlockers).map(
+        async ([prNumber, approversAndBlockers]) => {
+          const pr = await fetchPr(Number(prNumber));
+          const result = await getPrReviewers(pr);
+          assertEquals(result.approvers, approversAndBlockers.approvers);
+          assertEquals(result.blockers, approversAndBlockers.blockers);
+        },
+      ),
+    );
+  });
 
-Deno.test('fetchBranch("main") returns the appropriate main branch', async () => {
-  const mainBranch = await fetchBranch("main");
-  assertEquals(mainBranch.name, "main");
-  assertEquals(mainBranch.protected, true);
-  assertEquals(
-    mainBranch._links.html,
-    "https://github.com/go-gitea/gitea/tree/main",
-  );
-});
+  it('fetchBranch("main") returns the appropriate main branch', async () => {
+    const mainBranch = await fetchBranch("main");
+    assertEquals(mainBranch.name, "main");
+    assertEquals(mainBranch.protected, true);
+    assertEquals(
+      mainBranch._links.html,
+      "https://github.com/go-gitea/gitea/tree/main",
+    );
+  });
 
-Deno.test("fetchBranch() handles full ref name well", async () => {
-  const [mainBranch, releaseV119Branch] = await Promise.all([
-    fetchBranch("refs/heads/main"),
-    fetchBranch("refs/heads/release/v1.19"),
-  ]);
-  assertEquals(mainBranch.name, "main");
-  assertEquals(mainBranch.protected, true);
-  assertEquals(
-    mainBranch._links.html,
-    "https://github.com/go-gitea/gitea/tree/main",
-  );
-  assertEquals(releaseV119Branch.name, "release/v1.19");
-  assertEquals(releaseV119Branch.protected, true);
-  assertEquals(
-    releaseV119Branch._links.html,
-    "https://github.com/go-gitea/gitea/tree/release/v1.19",
-  );
+  it("fetchBranch() handles full ref name well", async () => {
+    const [mainBranch, releaseV119Branch] = await Promise.all([
+      fetchBranch("refs/heads/main"),
+      fetchBranch("refs/heads/release/v1.19"),
+    ]);
+    assertEquals(mainBranch.name, "main");
+    assertEquals(mainBranch.protected, true);
+    assertEquals(
+      mainBranch._links.html,
+      "https://github.com/go-gitea/gitea/tree/main",
+    );
+    assertEquals(releaseV119Branch.name, "release/v1.19");
+    assertEquals(releaseV119Branch.protected, true);
+    assertEquals(
+      releaseV119Branch._links.html,
+      "https://github.com/go-gitea/gitea/tree/release/v1.19",
+    );
+  });
 });

--- a/src/user.ts
+++ b/src/user.ts
@@ -1,0 +1,7 @@
+import { fetchCurrentUser } from "./github.ts";
+
+export let bot: { login: string; email: string };
+
+export const init = async () => {
+  bot = await fetchCurrentUser();
+};


### PR DESCRIPTION
GitHub only counts reviews from users with write access to a repository. That means we can't use GitHub's setting to require 2 approvals in `go-gitea/gitea` because it wouldn't count approvals from maintainers without write access (like myself).

The previous solution for this problem was maintaining our own status check that counts approvals from non-merger maintainers and mergers and passes when 2 approvals have been counted (it would stay pending otherwise). With the new approach, we will drop the previous solution and have the bot "echo" non-merger maintainer reviews. The bot has write access so its approval will be counted.

## Pros
- Integration with GitHub's approval system
- If a PR passes all checks but doesn't have enough approvals, it will show the green checkmark instead of the pending yellow dot
- No more `lgtm` labels (GitHub's UI will show the approval count)

## Cons
- Duplicate reviews, if a non-merger maintainer approves, immediately the bot would approve
- Currently, we use only one bot account so if 2 non-merger maintainers approve it will only count once on GitHub (essentially this means at least one merger has to approve for the PR to land, which has been the case for almost all PRs anyway)

## Action Items
- Add an organization webhook on `go-gitea` with the same URL and secret, select the `membership` event
  - Instead of maintaining 2 webhooks (one on `go-gitea` and another on `go-gitea/gitea`) we can select all events from the `go-gitea/gitea` webhook also on the `go-gitea` webhook and delete the `go-gitea/gitea` webhook
 - Remove the required `giteabot/lgtm` check from `go-gitea/gitea`
 - Set the GitHub setting to require 2 approvals

## Warning
I didn't test this, we'll have to merge and then test (as we did when we merged #51)