### PR TITLE
Make sure PRs that include `## :warning: BREAKING` in their body have the `kind/breaking` label

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ The script will also look for merged pull requests that have the labels
 It will also search for pull requests that target release branches and remove
 any `backport/*` labels from them.
 
+It will also make sure any pull requests that have
+`## :warning: BREAKING :warning:` in their description have the `kind/breaking`
+label.
+
 ### Merge queue synchronization
 
 The script will also look for pull requests that have the label

--- a/README.md
+++ b/README.md
@@ -25,9 +25,8 @@ The script will also look for merged pull requests that have the labels
 It will also search for pull requests that target release branches and remove
 any `backport/*` labels from them.
 
-It will also make sure any pull requests that have
-`## :warning: BREAKING :warning:` in their description have the `kind/breaking`
-label.
+It will also make sure any pull requests that have `## :warning: BREAKING` in
+their description have the `kind/breaking` label.
 
 ### Merge queue synchronization
 

--- a/src/github.ts
+++ b/src/github.ts
@@ -81,6 +81,19 @@ export const fetchUnmergedClosedWithMilestone = async (
   return json;
 };
 
+// returns a list of breaking PRs that don't have the label kind/breaking
+export const fetchBreakingWithoutLabel = async () => {
+  const response = await fetch(
+    `${GITHUB_API}/search/issues?q=` +
+      encodeURIComponent(
+        `is:pr "## :warning: BREAKING :warning:" -label:kind/breaking repo:go-gitea/gitea`,
+      ),
+    { headers: HEADERS },
+  );
+  const json = await response.json();
+  return json;
+};
+
 // update a given PR with the latest upstream changes by merging HEAD from
 // the base branch into the pull request branch
 export const updatePr = async (prNumber: number): Promise<Response> => {

--- a/src/github.ts
+++ b/src/github.ts
@@ -86,7 +86,7 @@ export const fetchBreakingWithoutLabel = async () => {
   const response = await fetch(
     `${GITHUB_API}/search/issues?q=` +
       encodeURIComponent(
-        `is:pr "## :warning: BREAKING :warning:" -label:kind/breaking repo:go-gitea/gitea`,
+        `is:pr "## :warning: BREAKING" -label:kind/breaking repo:go-gitea/gitea`,
       ),
     { headers: HEADERS },
   );

--- a/src/labels.ts
+++ b/src/labels.ts
@@ -1,4 +1,10 @@
-import { fetchMergedWithLabel, fetchTargeting, removeLabel } from "./github.ts";
+import {
+  addLabels,
+  fetchBreakingWithoutLabel,
+  fetchMergedWithLabel,
+  fetchTargeting,
+  removeLabel,
+} from "./github.ts";
 import { fetchGiteaVersions } from "./giteaVersion.ts";
 import { debounce } from "https://deno.land/std@0.186.0/async/mod.ts";
 
@@ -17,7 +23,16 @@ const maintain = async () => {
   await Promise.all([
     removeLabelsFromMergedPr(labelsToRemoveAfterMerge),
     removeBackportLabelsFromPrsTargetingReleaseBranches(),
+    addKindBreakingToBreakingPrs(),
   ]);
+};
+
+// add kind/breaking to all breaking PRs that don't have it
+const addKindBreakingToBreakingPrs = async () => {
+  const breakingPrs = await fetchBreakingWithoutLabel();
+  return Promise.all(breakingPrs.items.map(async (pr: { number: number }) => {
+    await addLabels(pr.number, ["kind/breaking"]);
+  }));
 };
 
 const removeLabelFromMergedPr = async (

--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -46,6 +46,11 @@ webhook.on(
   },
 );
 
+// on pull request open, run the label maintenance
+webhook.on("pull_request.opened", () => {
+  labels.run();
+});
+
 // on pull request creation, we'll automatically set the milestone
 // according to the target branch (if it's a release branch)
 webhook.on("pull_request.opened", ({ payload }) => {


### PR DESCRIPTION
Just a small addition because this can be automated