### PR TITLE
Direct users who add non-english translation changes to crowdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ request has. It will also set the commit status to `success` if the pull request
 has 2 or more approvals without changes requested (`pending` if not or `failure`
 if changes are requested).
 
+### Comments
+
+The script will also comment if a pull request is opened with non-English
+translation files changed, directing the user to the crowdin project.
+
 ## Usage
 
 Set the following environment variables:

--- a/src/comments.ts
+++ b/src/comments.ts
@@ -1,0 +1,17 @@
+import { addPrComment, fetchPrFileNames } from "./github.ts";
+
+export const commentIfTranslationsChanged = async (
+  pr: { number: number; user: { login: string } },
+) => {
+  const prFileNamesSet = await fetchPrFileNames(pr.number);
+  const prFileNames = Array.from(prFileNamesSet);
+  const translationsChanged = prFileNames.some((fileName) =>
+    fileName.startsWith("options/locale/") && fileName.endsWith(".ini") &&
+    !fileName.endsWith("en-US.ini")
+  );
+  if (translationsChanged) {
+    const comment =
+      `@${pr.user.login} I noticed you've updated the locales for non-English languages. These will be overwritten during the sync from our translation tool Crowdin. If you'd like to contribute your translations, please visit https://crowdin.com/project/gitea. Please revert the changes done on these files. :tea:`;
+    await addPrComment(pr.number, comment);
+  }
+};

--- a/src/github.ts
+++ b/src/github.ts
@@ -94,6 +94,25 @@ export const fetchBreakingWithoutLabel = async () => {
   return json;
 };
 
+// returns a list of files changed in the given PR number
+export const fetchPrFileNames = async (prNumber: number) => {
+  const files: { filename: string }[] = [];
+  let page = 1;
+  while (true) {
+    const response = await fetch(
+      `${GITHUB_API}/repos/go-gitea/gitea/pulls/${prNumber}/files?per_page=100&page=${page}`,
+      { headers: HEADERS },
+    );
+    const json = await response.json();
+    files.push(...json);
+    if (json.length < 100) {
+      break;
+    }
+    page++;
+  }
+  return new Set(files.map((file) => file.filename));
+};
+
 // update a given PR with the latest upstream changes by merging HEAD from
 // the base branch into the pull request branch
 export const updatePr = async (prNumber: number): Promise<Response> => {

--- a/src/github_test.ts
+++ b/src/github_test.ts
@@ -1,5 +1,10 @@
 import { assertEquals } from "https://deno.land/std@0.189.0/testing/asserts.ts";
-import { fetchBranch, fetchPr, getPrReviewers } from "./github.ts";
+import {
+  fetchBranch,
+  fetchPr,
+  fetchPrFileNames,
+  getPrReviewers,
+} from "./github.ts";
 
 Deno.test("getPrReviewers() returns the appropriate approvers", async () => {
   const prToApproversAndBlockers = {
@@ -84,4 +89,31 @@ Deno.test("fetchBranch() handles full ref name well", async () => {
     releaseV119Branch._links.html,
     "https://github.com/go-gitea/gitea/tree/release/v1.19",
   );
+});
+
+Deno.test("fetchPrFileNames() returns the appropriate files", async () => {
+  const prToFiles = {
+    25432: new Set([
+      "modules/setting/database.go",
+      "options/locale/locale_en-US.ini",
+      "routers/install/install.go",
+      "services/forms/user_form.go",
+      "templates/install.tmpl",
+    ]),
+    24825: new Set(["models/repo/topic.go"]),
+  };
+
+  await Promise.all(
+    Object.entries(prToFiles).map(
+      async ([prNumber, files]) => {
+        const result = await fetchPrFileNames(Number(prNumber));
+        assertEquals(result, files);
+      },
+    ),
+  );
+});
+
+Deno.test("fetchPrFileNames() can handle big PRs", async () => {
+  const aPrWith669Files = await fetchPrFileNames(24147);
+  assertEquals(aPrWith669Files.size, 669);
 });

--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -6,6 +6,7 @@ import * as labels from "./labels.ts";
 import * as mergeQueue from "./mergeQueue.ts";
 import * as milestones from "./milestones.ts";
 import * as lgtm from "./lgtm.ts";
+import * as comments from "./comments.ts";
 
 const secret = Deno.env.get("BACKPORTER_GITHUB_SECRET");
 
@@ -49,6 +50,11 @@ webhook.on(
 // on pull request open, run the label maintenance
 webhook.on("pull_request.opened", () => {
   labels.run();
+});
+
+// on pull request open, comment if translations changed
+webhook.on("pull_request.opened", ({ payload }) => {
+  comments.commentIfTranslationsChanged(payload.pull_request);
 });
 
 // on pull request creation, we'll automatically set the milestone


### PR DESCRIPTION
This commit adds a new script that will comment on a pull request if it is opened with non-English translation files changed, directing the user to the crowdin project. Also added a new function that returns the list of files changed in the given PR number. Tests were included to test the new functionality.

Close #90