### PR TITLE
Only comment on translation changes if the PR is targeting `main`

### DIFF
--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -52,8 +52,11 @@ webhook.on("pull_request.opened", () => {
   labels.run();
 });
 
-// on pull request open, comment if translations changed
+// on pull request open, comment if translations changed (only if the PR is targeting main)
 webhook.on("pull_request.opened", ({ payload }) => {
+  if (payload.pull_request.base.ref !== "main") {
+    return;
+  }
   comments.commentIfTranslationsChanged(payload.pull_request);
 });
 


### PR DESCRIPTION
Locale backports are appropriate

Avoid commenting on PRs like https://github.com/go-gitea/gitea/pull/25635 and https://github.com/go-gitea/gitea/pull/25668
![image](https://github.com/GiteaBot/gitea-backporter/assets/20454870/bb3b5e75-b617-4a2e-9fc5-2e5857d9bb39)
