### PR TITLE
Lock issues closed for 3 months and pull requests merged/closed for 3 months automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ if changes are requested).
 The script will also comment if a pull request is opened with non-English
 translation files changed, directing the user to the crowdin project.
 
+### Locks
+
+The script will also lock issues and pull requests that have been closed for 3
+months. If the issue was updated in the last month, a comment will be posted
+suggesting opening a new issue to continue the discussion.
+
 ## Usage
 
 Set the following environment variables:

--- a/src/backport.ts
+++ b/src/backport.ts
@@ -1,8 +1,8 @@
 import { cherryPickPr, initializeGitRepo } from "./git.ts";
 import { fetchGiteaVersions, GiteaVersion } from "./giteaVersion.ts";
 import {
+  addComment,
   addLabels,
-  addPrComment,
   backportPrExists,
   createBackportPr,
   fetchCandidates,
@@ -46,7 +46,7 @@ const parseCandidate = async (candidate, giteaVersion: GiteaVersion) => {
   );
 
   if (!success) {
-    await addPrComment(
+    await addComment(
       originalPr.number,
       `I was unable to create a backport for ${giteaVersion.majorMinorVersion}. @${originalPr.user.login}, please send one manually. :tea:
 

--- a/src/comments.ts
+++ b/src/comments.ts
@@ -1,4 +1,4 @@
-import { addPrComment, fetchPrFileNames } from "./github.ts";
+import { addComment, fetchPrFileNames } from "./github.ts";
 
 export const commentIfTranslationsChanged = async (
   pr: { number: number; user: { login: string } },
@@ -12,6 +12,6 @@ export const commentIfTranslationsChanged = async (
   if (translationsChanged) {
     const comment =
       `@${pr.user.login} I noticed you've updated the locales for non-English languages. These will be overwritten during the sync from our translation tool Crowdin. If you'd like to contribute your translations, please visit https://crowdin.com/project/gitea. Please revert the changes done on these files. :tea:`;
-    await addPrComment(pr.number, comment);
+    await addComment(pr.number, comment);
   }
 };

--- a/src/lock.ts
+++ b/src/lock.ts
@@ -22,9 +22,9 @@ export const run = async () => {
         if (lockedSuccessfully && new Date(issue.updated_at) > oneMonthAgo) {
           await addComment(
             issue.number,
-            `Hi, we lock ${
+            `We lock ${
               issue.pull_request ? "pull request" : "issue"
-            }s if 3 months have passed since they were closed. If there's any need for a further discussion, please open a new issue. :tea:`,
+            }s 3 months after they were closed. If there's any need for further discussion, please open a new issue. :tea:`,
           );
         }
       },

--- a/src/lock.ts
+++ b/src/lock.ts
@@ -1,0 +1,33 @@
+import { addComment, fetchClosedOldIssuesAndPRs, lockIssue } from "./github.ts";
+
+const MILLISECONDS_IN_A_MONTH = 1000 * 60 * 60 * 24 * 30;
+
+// adds a comment and locks old issues and PRs
+export const run = async () => {
+  const oneMonthAgo = new Date(Date.now() - MILLISECONDS_IN_A_MONTH);
+  const threeMonthsAgo = new Date(Date.now() - MILLISECONDS_IN_A_MONTH * 3);
+  const issues = await fetchClosedOldIssuesAndPRs(threeMonthsAgo);
+  return Promise.all(
+    issues.map(
+      async (
+        issue: {
+          number: number;
+          pull_request?: { url: string };
+          updated_at: string;
+        },
+      ) => {
+        const lockedSuccessfully = await lockIssue(issue.number, "resolved");
+
+        // if the issue was updated in the last month, we add a comment
+        if (lockedSuccessfully && new Date(issue.updated_at) > oneMonthAgo) {
+          await addComment(
+            issue.number,
+            `Hi, we lock ${
+              issue.pull_request ? "pull request" : "issue"
+            }s if 3 months have passed since they were closed. If there's any need for a further discussion, please open a new issue. :tea:`,
+          );
+        }
+      },
+    ),
+  );
+};

--- a/src/mergeQueue.ts
+++ b/src/mergeQueue.ts
@@ -1,5 +1,5 @@
 import {
-  addPrComment,
+  addComment,
   fetchPendingMerge,
   needsUpdate,
   removeLabel,
@@ -32,7 +32,7 @@ const updateBranch = async () => {
     );
     // if there is a merge conflict, we'll add a comment to fix the conflicts and remove the reviewed/wait-merge label
     await Promise.all([
-      addPrComment(
+      addComment(
         pr.number,
         `@${pr.user.login} please fix the merge conflicts. :tea:`,
       ),

--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -7,6 +7,7 @@ import * as mergeQueue from "./mergeQueue.ts";
 import * as milestones from "./milestones.ts";
 import * as lgtm from "./lgtm.ts";
 import * as comments from "./comments.ts";
+import * as lock from "./lock.ts";
 
 const secret = Deno.env.get("BACKPORTER_GITHUB_SECRET");
 
@@ -29,9 +30,10 @@ webhook.on("push", ({ payload }) => {
     backport.run();
   }
 
-  // we should take this opportunity to run the label and merge queue maintenance
+  // we should take this opportunity to run the label, merge queue, and lock maintenance
   labels.run();
   mergeQueue.run();
+  lock.run();
 });
 
 // on pull request labeling events, run the label and merge queue maintenance


### PR DESCRIPTION
We will lock issues and pull requests that have been closed for 3 months. If the issue was updated in the last month, a comment will be posted suggesting opening a new issue to continue the discussion.

The check is done on every push and will lock at most 30 issues at a time. We currently have ~400 issues awaiting for locking so the initial locking will happen over the next few days.

Closes #96 