### PR TITLE
Update locking script to add comments for issues updated within the last two weeks

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ translation files changed, directing the user to the crowdin project.
 ### Locks
 
 The script will also lock issues and pull requests that have been closed for 3
-months. If the issue was updated in the last month, a comment will be posted
+months. If the issue was updated in the last two weeks, a comment will be posted
 suggesting opening a new issue to continue the discussion.
 
 ## Usage

--- a/src/lock.ts
+++ b/src/lock.ts
@@ -1,11 +1,11 @@
 import { addComment, fetchClosedOldIssuesAndPRs, lockIssue } from "./github.ts";
 
-const MILLISECONDS_IN_A_MONTH = 1000 * 60 * 60 * 24 * 30;
+const MILLISECONDS_IN_A_DAY = 1000 * 60 * 60 * 24;
 
 // adds a comment and locks old issues and PRs
 export const run = async () => {
-  const oneMonthAgo = new Date(Date.now() - MILLISECONDS_IN_A_MONTH);
-  const threeMonthsAgo = new Date(Date.now() - MILLISECONDS_IN_A_MONTH * 3);
+  const twoWeeksAgo = new Date(Date.now() - MILLISECONDS_IN_A_DAY * 14);
+  const threeMonthsAgo = new Date(Date.now() - MILLISECONDS_IN_A_DAY * 90);
   const issues = await fetchClosedOldIssuesAndPRs(threeMonthsAgo);
   return Promise.all(
     issues.items.map(
@@ -18,8 +18,8 @@ export const run = async () => {
       ) => {
         const lockedSuccessfully = await lockIssue(issue.number, "resolved");
 
-        // if the issue was updated in the last month, we add a comment
-        if (lockedSuccessfully && new Date(issue.updated_at) > oneMonthAgo) {
+        // if the issue was updated in the two weeks, we add a comment
+        if (lockedSuccessfully && new Date(issue.updated_at) > twoWeeksAgo) {
           await addComment(
             issue.number,
             `We lock ${


### PR DESCRIPTION
- Reduced the time threshold for adding a comment from one month to two weeks.
- Adjusted the calculation of time thresholds in the `run` function of `lock.ts`.
- Updated the code comments to reflect the new time threshold.

Closes #96 (again)