### PR TITLE
Refactor locking logic to check the last comment date

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ translation files changed, directing the user to the crowdin project.
 ### Locks
 
 The script will also lock issues and pull requests that have been closed for 3
-months. If the issue was updated in the last two weeks, a comment will be posted
-suggesting opening a new issue to continue the discussion.
+months. If the issue was commented on in the last two weeks, a comment will be
+posted suggesting opening a new issue to continue the discussion.
 
 ## Usage
 

--- a/src/github.ts
+++ b/src/github.ts
@@ -471,6 +471,6 @@ export const fetchLastComment = async (issueNumber: number) => {
     { headers: HEADERS },
   );
   const json = await response.json();
-  if (json.length === 0) return null;
+  if (!json.length) return null;
   return json[0];
 };

--- a/src/github.ts
+++ b/src/github.ts
@@ -463,3 +463,14 @@ export const fetchClosedOldIssuesAndPRs = async (before: Date) => {
   const json = await response.json();
   return json;
 };
+
+// returns the last comment of the given issue
+export const fetchLastComment = async (issueNumber: number) => {
+  const response = await fetch(
+    `${GITHUB_API}/repos/go-gitea/gitea/issues/${issueNumber}/comments?per_page=1&sort=created&direction=desc`,
+    { headers: HEADERS },
+  );
+  const json = await response.json();
+  if (json.length === 0) return null;
+  return json[0];
+};

--- a/src/github_test.ts
+++ b/src/github_test.ts
@@ -1,6 +1,10 @@
-import { assertEquals } from "https://deno.land/std@0.189.0/testing/asserts.ts";
+import {
+  assertEquals,
+  assertFalse,
+} from "https://deno.land/std@0.189.0/testing/asserts.ts";
 import {
   fetchBranch,
+  fetchLastComment,
   fetchPr,
   fetchPrFileNames,
   getPrReviewers,
@@ -116,4 +120,27 @@ Deno.test("fetchPrFileNames() returns the appropriate files", async () => {
 Deno.test("fetchPrFileNames() can handle big PRs", async () => {
   const aPrWith669Files = await fetchPrFileNames(24147);
   assertEquals(aPrWith669Files.size, 669);
+});
+
+Deno.test("fetchLastComment() returns the appropriate comment", async () => {
+  const prToLastComment = {
+    10: "Closing as fixed by #199 ",
+    29: null,
+    1000: "LGTM",
+    10000:
+      "It is a feature of SQL databases. The repo id is stored in the database and uses auto increment:\r\nhttps://www.w3schools.com/sql/sql_autoincrement.asp",
+  };
+  await Promise.all(
+    Object.entries(prToLastComment).map(
+      async ([issueNumber, comment]) => {
+        const result = await fetchLastComment(Number(issueNumber));
+        if (comment === null) {
+          assertFalse(result);
+          return;
+        }
+
+        assertEquals(result.body, comment);
+      },
+    ),
+  );
 });

--- a/src/github_test.ts
+++ b/src/github_test.ts
@@ -134,11 +134,7 @@ Deno.test("fetchLastComment() returns the appropriate comment", async () => {
     Object.entries(prToLastComment).map(
       async ([issueNumber, comment]) => {
         const result = await fetchLastComment(Number(issueNumber));
-        if (comment === null) {
-          assertFalse(result);
-          return;
-        }
-
+        if (!comment) return assertFalse(result);
         assertEquals(result.body, comment);
       },
     ),


### PR DESCRIPTION
- Added `fetchLastComment` function to retrieve the last comment of an issue
- Updated `run` function in `lock.ts` to use `fetchLastComment` to check the date of the last comment before adding a new comment
- Improved logic to determine if there is an active discussion before adding a new comment

Closes #96 