### PR TITLE
Check maintainers can modify before attempting to update

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -162,6 +162,9 @@ export const needsUpdate = async (prNumber: number) => {
   // get the PR and check if its base sha is the same as its base branch
   const pr = await fetchPr(prNumber);
 
+  // if maintainers can't modify the PR, it doesn't need to be updated
+  if (!pr.maintainer_can_modify) return false;
+
   // if the PR is not open, it doesn't need to be updated
   if (pr.state !== "open") return false;
 


### PR DESCRIPTION
To avoid messages such as `{"message":"user doesn't have permission to update head repository","documentation_url":"https://docs.github.com/rest/pulls/pulls#update-a-pull-request-branch"}`