### PR TITLE
add ability to update PR by adding a label

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ The script will also lock issues and pull requests that have been closed for 3
 months. If the issue was commented on in the last two weeks, a comment will be
 posted suggesting opening a new issue to continue the discussion.
 
+### Maintainer commands
+
+The script can execute some actions like updating a PR's branch if requested by
+a maintainer through a `giteabot/*` label.
+
 ## Usage
 
 Set the following environment variables:

--- a/src/labels.ts
+++ b/src/labels.ts
@@ -12,7 +12,7 @@ import { debounce } from "https://deno.land/std@0.189.0/async/mod.ts";
 // manage backports or any other label that causes the bot to act on
 // detection, such as reviewed/* or backport/*
 export const isRelevantLabel = (label: string): boolean => {
-  return label.startsWith("reviewed/") || label.startsWith("backport/");
+  return label.startsWith("reviewed/") || label.startsWith("backport/") || label.startsWith("giteabot/");
 };
 
 const maintain = async () => {

--- a/src/labels.ts
+++ b/src/labels.ts
@@ -12,7 +12,8 @@ import { debounce } from "https://deno.land/std@0.189.0/async/mod.ts";
 // manage backports or any other label that causes the bot to act on
 // detection, such as reviewed/* or backport/*
 export const isRelevantLabel = (label: string): boolean => {
-  return label.startsWith("reviewed/") || label.startsWith("backport/") || label.startsWith("giteabot/");
+  return label.startsWith("reviewed/") || label.startsWith("backport/") ||
+    label.startsWith("giteabot/");
 };
 
 const maintain = async () => {

--- a/src/mergeQueue.ts
+++ b/src/mergeQueue.ts
@@ -1,10 +1,9 @@
 import {
   addComment,
   fetchPendingMerge,
-  needsUpdate,
   removeLabel,
-  updatePr,
 } from "./github.ts";
+import * as prActions from "./prActions.ts";
 import { debounce } from "https://deno.land/std@0.189.0/async/mod.ts";
 
 const updateBranch = async () => {
@@ -13,31 +12,12 @@ const updateBranch = async () => {
 
   // update all PRs pending merge (only if they need an update)
   for (const pr of pendingMerge.items) {
-    if (!await needsUpdate(pr.number)) continue;
-    const response = await updatePr(pr.number);
-    if (response.ok) {
-      console.info(`Synced PR #${pr.number} in merge queue`);
-      continue;
-    }
+    const err = await prActions.updateBranch(pr)
 
-    const body = await response.json();
-    if (body.message !== "merge conflict between base and head") {
-      console.error(`Failed to sync PR #${pr.number} in merge queue`);
-      console.error(JSON.stringify(body));
-      continue;
+    if (err?.message == "merge conflicts in PR") {
+      // if there is a merge conflict, we'll remove the reviewed/wait-merge label
+      await removeLabel(pr.number, "reviewed/wait-merge")
     }
-
-    console.info(
-      `Merge conflict detected in PR #${pr.number} in merge queue`,
-    );
-    // if there is a merge conflict, we'll add a comment to fix the conflicts and remove the reviewed/wait-merge label
-    await Promise.all([
-      addComment(
-        pr.number,
-        `@${pr.user.login} please fix the merge conflicts. :tea:`,
-      ),
-      removeLabel(pr.number, "reviewed/wait-merge"),
-    ]);
   }
 };
 

--- a/src/mergeQueue.ts
+++ b/src/mergeQueue.ts
@@ -1,8 +1,4 @@
-import {
-  addComment,
-  fetchPendingMerge,
-  removeLabel,
-} from "./github.ts";
+import { fetchPendingMerge, removeLabel } from "./github.ts";
 import * as prActions from "./prActions.ts";
 import { debounce } from "https://deno.land/std@0.189.0/async/mod.ts";
 
@@ -12,11 +8,11 @@ const updateBranch = async () => {
 
   // update all PRs pending merge (only if they need an update)
   for (const pr of pendingMerge.items) {
-    const err = await prActions.updateBranch(pr)
+    const err = await prActions.updateBranch(pr);
 
     if (err?.message == "merge conflicts in PR") {
       // if there is a merge conflict, we'll remove the reviewed/wait-merge label
-      await removeLabel(pr.number, "reviewed/wait-merge")
+      await removeLabel(pr.number, "reviewed/wait-merge");
     }
   }
 };

--- a/src/prActions.ts
+++ b/src/prActions.ts
@@ -5,11 +5,9 @@ const execute = async (
   label: string,
   pr: { number: number; user: { login: string } },
 ) => {
-  switch (label) {
-    case "giteabot/update-branch": {
-      await updateBranch(pr);
-      await removeLabel(pr.number, "giteabot/update-branch");
-    }
+  if (label === "giteabot/update-branch") {
+    await updateBranch(pr);
+    await removeLabel(pr.number, "giteabot/update-branch");
   }
 };
 

--- a/src/prActions.ts
+++ b/src/prActions.ts
@@ -1,9 +1,4 @@
-import {
-  addComment,
-  needsUpdate,
-  removeLabel,
-  updatePr,
-} from "./github.ts";
+import { addComment, needsUpdate, removeLabel, updatePr } from "./github.ts";
 import { debounce } from "https://deno.land/std@0.189.0/async/mod.ts";
 
 const execute = async (
@@ -26,7 +21,7 @@ const updateBranch = async (
       console.info(`Synced PR #${pr.number} as requested by a maintainer`);
       return;
     }
-    
+
     const body = await response.json();
     if (body.message !== "merge conflict between base and head") {
       console.error(

--- a/src/prActions.ts
+++ b/src/prActions.ts
@@ -1,0 +1,55 @@
+import {
+  addComment,
+  needsUpdate,
+  removeLabel,
+  updatePr,
+} from "./github.ts";
+import { debounce } from "https://deno.land/std@0.189.0/async/mod.ts";
+
+const execute = async (
+  label: string,
+  pr: { number: number; user: { login: string } },
+) => {
+  switch (label) {
+    case "giteabot/update-branch":
+      await updateBranch(pr);
+  }
+};
+
+const updateBranch = async (
+  pr: { number: number; user: { login: string } },
+) => {
+  await removeLabel(pr.number, "giteabot/update-branch");
+  if (await needsUpdate(pr.number)) {
+    const response = await updatePr(pr.number);
+    if (response.ok) {
+      console.info(`Synced PR #${pr.number} as requested by a maintainer`);
+      return;
+    }
+    
+    const body = await response.json();
+    if (body.message !== "merge conflict between base and head") {
+      console.error(
+        `Failed to sync PR #${pr.number} as requested by maintainer`,
+      );
+      console.error(JSON.stringify(body));
+      await addComment(
+        pr.number,
+        `Failed to update branch :tea:`,
+      );
+      return;
+    }
+
+    console.info(
+      `Merge conflict detected in PR #${pr.number}`,
+    );
+    // if there is a merge conflict, we'll add a comment to fix the conflicts
+    await addComment(
+      pr.number,
+      `@${pr.user.login} please fix the merge conflicts. :tea:`,
+    );
+  }
+};
+
+// make sure we don't trigger too often
+export const run = debounce(execute, 8000);

--- a/src/prActions.ts
+++ b/src/prActions.ts
@@ -14,7 +14,7 @@ const execute = async (
           pr.number,
           `Failed to update branch :tea:`,
         );
-      }  
+      }
       await removeLabel(pr.number, "giteabot/update-branch");
     }
   }
@@ -47,7 +47,7 @@ export const updateBranch = async (
       pr.number,
       `@${pr.user.login} please fix the merge conflicts. :tea:`,
     );
-    return Error("merge conflicts in PR")
+    return Error("merge conflicts in PR");
   }
 };
 

--- a/src/prActions.ts
+++ b/src/prActions.ts
@@ -7,14 +7,7 @@ const execute = async (
 ) => {
   switch (label) {
     case "giteabot/update-branch": {
-      const err = await updateBranch(pr);
-      if (err?.message == "failed to sync PR") {
-        // notify maintainer about failed update
-        await addComment(
-          pr.number,
-          `Failed to update branch :tea:`,
-        );
-      }
+      await updateBranch(pr);
       await removeLabel(pr.number, "giteabot/update-branch");
     }
   }
@@ -36,7 +29,6 @@ export const updateBranch = async (
         `Failed to sync PR #${pr.number}`,
       );
       console.error(JSON.stringify(body));
-      return Error("failed to sync PR");
     }
 
     console.info(

--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -8,6 +8,7 @@ import * as milestones from "./milestones.ts";
 import * as lgtm from "./lgtm.ts";
 import * as comments from "./comments.ts";
 import * as lock from "./lock.ts";
+import * as prActions from "./prActions.ts";
 
 const secret = Deno.env.get("BACKPORTER_GITHUB_SECRET");
 
@@ -45,6 +46,7 @@ webhook.on(
     if (labels.isRelevantLabel(payload.label.name)) {
       labels.run();
       mergeQueue.run();
+      prActions.run(payload.label.name, payload.pull_request);
     }
   },
 );


### PR DESCRIPTION
This feature allows a maintainer to update a PR's branch by adding the `giteabot/update-branch` label. It is being removed after the update.