### PR TITLE
Fix feedback label name

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ posted suggesting opening a new issue to continue the discussion.
 
 ### Feedback
 
-The script will close issues with the label `status/needs-feedback` if a month
+The script will close issues with the label `issue/needs-feedback` if a month
 has passed since they were updated.
 
 ### Maintainer commands

--- a/src/feedback.ts
+++ b/src/feedback.ts
@@ -3,7 +3,7 @@ import { addComment, closeIssue, fetchOpenIssuesWithLabel } from "./github.ts";
 export const run = async () => {
   // get all issues with the label "status/needs-feedback"
   const issuesWithStatusNeedsFeedback = await fetchOpenIssuesWithLabel(
-    "status/needs-feedback",
+    "issue/needs-feedback",
   );
   return Promise.all(issuesWithStatusNeedsFeedback.items.map(handleIssue));
 };


### PR DESCRIPTION
The label `status/needs-feedback` is now `issue/needs-feedback`.

- Fixes #113