### PR TITLE
Remove `pr/last-call` label on merge

### DIFF
--- a/src/labels.ts
+++ b/src/labels.ts
@@ -20,6 +20,7 @@ const maintain = async () => {
   const labelsToRemoveAfterMerge = [
     "reviewed/wait-merge",
     "reviewed/prioritize-merge",
+    "pr/last-call",
   ];
   await Promise.all([
     removeLabelsFromMergedPr(labelsToRemoveAfterMerge),


### PR DESCRIPTION
If a PR is successfully merged, there's no need to keep the `Last Call` metadata.
For unmerged closed PRs, this is different as there it is valuable information that it was only closed due to a lack of reviewers.