### PR TITLE
Fix app crashing on fly.io

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,4 @@ USER deno
 WORKDIR /app
 COPY src .
 RUN deno cache webhook.ts
-CMD ["run", "--allow-net", "--allow-env", "--allow-run", "webhook.ts"]
+CMD ["run", "--allow-net", "--allow-env", "--allow-run", "--allow-sys", "webhook.ts"]

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ BACKPORTER_GITEA_FORK= # The fork of go-gitea/gitea to push the backport branch 
 Then run:
 
 ```bash
-deno run --allow-net --allow-env --allow-run src/webhook.ts
+deno run --allow-net --allow-env --allow-run --allow-sys src/webhook.ts
 ```
 
 This will spin up a web server on port 8000. You can then set up a GitHub


### PR DESCRIPTION
Suddenly we need `--allow-sys` because octokit imports `https://esm.sh/v135/clean-stack@2.2.0/denonext/clean-stack.mjs`
    
I don't know why it's not pinned