### PR TITLE
Run typecheck on CI and fix issues

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -18,7 +18,8 @@ jobs:
       - uses: denoland/setup-deno@v1
       - run: deno fmt --check
       - run: deno lint
-      - run: deno check src/*.ts
+      - run: echo $SHELL
+      - run: shopt -s globstar; deno check src/**/*.ts
       - run: deno test -A
         env:
           BACKPORTER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: denoland/setup-deno@v1
       - run: deno fmt --check
       - run: deno lint

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: denoland/setup-deno@v1
       - run: deno fmt --check
       - run: deno lint
-      - run: echo src/**/*.ts
       - run: deno check src/*.ts
       - run: deno test -A
         env:

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -18,8 +18,7 @@ jobs:
       - uses: denoland/setup-deno@v1
       - run: deno fmt --check
       - run: deno lint
-      - run: echo $PWD
-      - run: ls -la $PWD
+      - run: echo src/**/*.ts
       - run: deno check src/*.ts
       - run: deno test -A
         env:

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -14,20 +14,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Setup repo
-        uses: actions/checkout@v3
-
-      - name: Setup Deno
-        uses: denoland/setup-deno@v1
-
-      - name: Verify formatting
-        run: deno fmt --check
-
-      - name: Run linter
-        run: deno lint
-
-      - name: Run tests
-        run: deno test -A
+      - uses: actions/checkout@v3
+      - uses: denoland/setup-deno@v1
+      - run: deno fmt --check
+      - run: deno lint
+      - run: deno check **/*.ts
+      - run: deno test -A
         env:
           BACKPORTER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BACKPORTER_GITEA_FORK: GiteaBot/gitea

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: denoland/setup-deno@v1
       - run: deno fmt --check
       - run: deno lint
-      - run: deno check **/*.ts
+      - run: deno check src/**/*.ts
       - run: deno test -A
         env:
           BACKPORTER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -20,7 +20,7 @@ jobs:
       - run: deno lint
       - run: echo $PWD
       - run: ls -la $PWD
-      - run: deno check src/**/*.ts
+      - run: deno check src/*.ts
       - run: deno test -A
         env:
           BACKPORTER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: denoland/setup-deno@v1
       - run: deno fmt --check
       - run: deno lint
-      - run: echo $SHELL
       - run: shopt -s globstar; deno check src/**/*.ts
       - run: deno test -A
         env:

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -18,6 +18,8 @@ jobs:
       - uses: denoland/setup-deno@v1
       - run: deno fmt --check
       - run: deno lint
+      - run: echo $PWD
+      - run: ls -la $PWD
       - run: deno check src/**/*.ts
       - run: deno test -A
         env:

--- a/deno.lock
+++ b/deno.lock
@@ -1,0 +1,31 @@
+{
+  "version": "3",
+  "remote": {
+    "https://deno.land/std@0.189.0/_util/asserts.ts": "178dfc49a464aee693a7e285567b3d0b555dc805ff490505a8aae34f9cfb1462",
+    "https://deno.land/std@0.189.0/async/abortable.ts": "fd682fa46f3b7b16b4606a5ab52a7ce309434b76f820d3221bdfb862719a15d7",
+    "https://deno.land/std@0.189.0/async/deadline.ts": "58f72a3cc0fcb731b2cc055ba046f4b5be3349ff6bf98f2e793c3b969354aab2",
+    "https://deno.land/std@0.189.0/async/debounce.ts": "adab11d04ca38d699444ac8a9d9856b4155e8dda2afd07ce78276c01ea5a4332",
+    "https://deno.land/std@0.189.0/async/deferred.ts": "42790112f36a75a57db4a96d33974a936deb7b04d25c6084a9fa8a49f135def8",
+    "https://deno.land/std@0.189.0/async/delay.ts": "73aa04cec034c84fc748c7be49bb15cac3dd43a57174bfdb7a4aec22c248f0dd",
+    "https://deno.land/std@0.189.0/async/mod.ts": "f04344fa21738e5ad6bea37a6bfffd57c617c2d372bb9f9dcfd118a1b622e576",
+    "https://deno.land/std@0.189.0/async/mux_async_iterator.ts": "70c7f2ee4e9466161350473ad61cac0b9f115cff4c552eaa7ef9d50c4cbb4cc9",
+    "https://deno.land/std@0.189.0/async/pool.ts": "f1b8d3df4d7fd3c73f8cbc91cc2e8b8e950910f1eab94230b443944d7584c657",
+    "https://deno.land/std@0.189.0/async/retry.ts": "c9248325ec08cc2cceb7618472e77589a51a25cee460e07b6096be34966c2ead",
+    "https://deno.land/std@0.189.0/async/tee.ts": "47e42d35f622650b02234d43803d0383a89eb4387e1b83b5a40106d18ae36757",
+    "https://deno.land/std@0.189.0/fmt/colors.ts": "d67e3cd9f472535241a8e410d33423980bec45047e343577554d3356e1f0ef4e",
+    "https://deno.land/std@0.189.0/http/server.ts": "1b23463b5b36e4eebc495417f6af47a6f7d52e3294827a1226d2a1aab23d9d20",
+    "https://deno.land/std@0.189.0/semver/mod.ts": "200f50cf6872212667df532fb09f0b1a33d3427a5201f75fad30a0d0c6dbcce3",
+    "https://deno.land/std@0.189.0/testing/_diff.ts": "1a3c044aedf77647d6cac86b798c6417603361b66b54c53331b312caeb447aea",
+    "https://deno.land/std@0.189.0/testing/_format.ts": "a69126e8a469009adf4cf2a50af889aca364c349797e63174884a52ff75cf4c7",
+    "https://deno.land/std@0.189.0/testing/asserts.ts": "e16d98b4d73ffc4ed498d717307a12500ae4f2cbe668f1a215632d19fcffc22f",
+    "https://esm.sh/@octokit/webhooks-methods@3.0.2": "1d78d63ca59569b6b0953436871e23847fe0b6fa278f086234db2e66469accff",
+    "https://esm.sh/@octokit/webhooks@11.0.0": "5dd3affa37b7437f15716c3a851e254fada03bea1d7f5c8df12da44713a74567"
+  },
+  "workspace": {
+    "packageJson": {
+      "dependencies": [
+        "npm:typescript@5.5.3"
+      ]
+    }
+  }
+}

--- a/src/backport.ts
+++ b/src/backport.ts
@@ -9,7 +9,7 @@ import {
   fetchCurrentUser,
   fetchPr,
 } from "./github.ts";
-import type {Issue} from "./types.ts";
+import type { Issue } from "./types.ts";
 
 if (
   !Deno.env.get("BACKPORTER_GITEA_FORK") ||

--- a/src/backport.ts
+++ b/src/backport.ts
@@ -9,6 +9,7 @@ import {
   fetchCurrentUser,
   fetchPr,
 } from "./github.ts";
+import type {Issue} from "./types.ts";
 
 if (
   !Deno.env.get("BACKPORTER_GITEA_FORK") ||
@@ -32,7 +33,7 @@ export const run = async () => {
   }
 };
 
-const parseCandidate = async (candidate, giteaVersion: GiteaVersion) => {
+const parseCandidate = async (candidate: Issue, giteaVersion: GiteaVersion) => {
   if (await backportPrExists(candidate, giteaVersion.majorMinorVersion)) {
     console.log(`Backport PR already exists for #${candidate.number}`);
     return;

--- a/src/labels.ts
+++ b/src/labels.ts
@@ -7,6 +7,7 @@ import {
 } from "./github.ts";
 import { fetchGiteaVersions } from "./giteaVersion.ts";
 import { debounce } from "https://deno.land/std@0.189.0/async/mod.ts";
+import type { PullRequest } from "./types.ts";
 
 // a relevant label is one that is used to control the merge queue,
 // manage backports or any other label that causes the bot to act on
@@ -77,15 +78,11 @@ export const removeBackportLabelsFromPrsTargetingReleaseBranches = async () => {
 };
 
 // given a list of PRs, removes the backport/* labels from them
-export const removeBackportLabelsFromPrs = (prs) => {
+export const removeBackportLabelsFromPrs = (prs: PullRequest[]) => {
   if (prs === undefined) {
     throw new Error("removeBackportLabelsFromPrs called with undefined");
   }
-  return Promise.all(prs.flatMap((pr: {
-    title;
-    labels;
-    number: number;
-  }) => {
+  return Promise.all(prs.flatMap((pr: PullRequest) => {
     const backportLabels = pr.labels.filter((label: { name: string }) =>
       label.name.startsWith("backport/")
     );

--- a/src/milestones.ts
+++ b/src/milestones.ts
@@ -1,6 +1,7 @@
 import * as SemVer from "https://deno.land/std@0.189.0/semver/mod.ts";
 import { fetchGiteaVersions } from "./giteaVersion.ts";
 import * as github from "./github.ts";
+import type { PullRequest } from "./types.ts";
 
 // given a PR number, set the milestone of the PR according to its base branch
 export const assign = async (pr: { number: number; base: { ref: string } }) => {
@@ -58,7 +59,7 @@ const removeMilestonesFromUnmergedClosedPrs = async () => {
   // and remove the milestone each PR
   return Promise.all(milestones.flatMap(async (m) => {
     const prs = await github.fetchUnmergedClosedWithMilestone(m.title);
-    return prs.items.map(async (pr) => {
+    return prs.items.map(async (pr: PullRequest) => {
       const response = await github.removeMilestone(pr.number);
       if (!response.ok) {
         console.error(

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,13 @@
-import { Endpoints } from 'npm:@octokit/types@13.5.0';
+import { Endpoints } from "npm:@octokit/types@13.5.0";
 
-type IssueGetResponse = Endpoints["GET /repos/{owner}/{repo}/issues/{issue_number}"]["response"]["data"];
-type PullGetResponse = Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}"]["response"]["data"];
+type IssueGetResponse =
+  Endpoints["GET /repos/{owner}/{repo}/issues/{issue_number}"]["response"][
+    "data"
+  ];
+type PullGetResponse =
+  Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}"]["response"][
+    "data"
+  ];
 
-export type Issue = IssueGetResponse
-export type PullRequest = PullGetResponse
+export type Issue = IssueGetResponse;
+export type PullRequest = PullGetResponse;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,7 @@
+import { Endpoints } from 'npm:@octokit/types@13.5.0';
+
+type IssueGetResponse = Endpoints["GET /repos/{owner}/{repo}/issues/{issue_number}"]["response"]["data"];
+type PullGetResponse = Endpoints["GET /repos/{owner}/{repo}/pulls/{pull_number}"]["response"]["data"];
+
+export type Issue = IssueGetResponse
+export type PullRequest = PullGetResponse

--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -94,6 +94,7 @@ webhook.on(
     "pull_request_review",
   ],
   ({ payload }) => {
+    // @ts-expect-error -- unknown
     lgtm.setPrStatusAndLabel(payload.pull_request);
   },
 );
@@ -128,6 +129,7 @@ serve(async (req: Request) => {
         status: 400,
       });
     }
+    // @ts-expect-error -- unknown
     webhook.receive({ id, name, payload: JSON.parse(requestBody) });
 
     return Response.json({ message: "Webhook received" });


### PR DESCRIPTION
1. type checking (`deno check`) was not running on CI and there were 7 type errors which I've fixed and now it's running
2. GitHub API types are sourced from https://github.com/octokit/types.ts and I created basic types for `Issue` and `PullRequest`.
3. IDK about those two webhook errors, so I used `@ts-expect-error`.
4. `deno.lock` was auto generated, I guess it's good to have it in-repo. 
5. `actions/checkout` is upgraded to latest major.