### PR TITLE
Add import maps and import standard library from jsr

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,3 @@
-**
-
-!src
+.git
+.github
+.vscode

--- a/.github/workflows/deploy-to-fly.yaml
+++ b/.github/workflows/deploy-to-fly.yaml
@@ -7,7 +7,7 @@ jobs:
     name: Deploy proxy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: superfly/flyctl-actions/setup-flyctl@master
       - run: flyctl deploy --remote-only
         env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,6 @@ RUN apt-get update && apt-get install -y git
 EXPOSE 8000
 USER deno
 WORKDIR /app
-COPY src .
-RUN deno cache --import-map deno.json webhook.ts
-CMD ["run", "--allow-net", "--allow-env", "--allow-run", "--allow-sys", "webhook.ts"]
+COPY . .
+RUN deno cache src/webhook.ts
+CMD ["run", "--allow-net", "--allow-env", "--allow-run", "--allow-sys", "src/webhook.ts"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,5 +4,5 @@ EXPOSE 8000
 USER deno
 WORKDIR /app
 COPY src .
-RUN deno cache webhook.ts
+RUN deno cache --import-map deno.json webhook.ts
 CMD ["run", "--allow-net", "--allow-env", "--allow-run", "--allow-sys", "webhook.ts"]

--- a/deno.json
+++ b/deno.json
@@ -1,0 +1,11 @@
+{
+  "imports": {
+    "@octokit/types": "npm:@octokit/types@13.5.0",
+    "@octokit/webhooks": "npm:@octokit/webhooks@11.0.0",
+    "@octokit/webhooks-methods": "npm:@octokit/webhooks-methods@3.0.2",
+    "@std/async": "jsr:@std/async@0.196.0",
+    "@std/http": "jsr:@std/http@0.196.0",
+    "@std/semver": "jsr:@std/semver@0.196.0",
+    "@std/testing": "jsr:@std/testing@0.196.0"
+  }
+}

--- a/deno.lock
+++ b/deno.lock
@@ -1,31 +1,153 @@
 {
   "version": "3",
-  "remote": {
-    "https://deno.land/std@0.189.0/_util/asserts.ts": "178dfc49a464aee693a7e285567b3d0b555dc805ff490505a8aae34f9cfb1462",
-    "https://deno.land/std@0.189.0/async/abortable.ts": "fd682fa46f3b7b16b4606a5ab52a7ce309434b76f820d3221bdfb862719a15d7",
-    "https://deno.land/std@0.189.0/async/deadline.ts": "58f72a3cc0fcb731b2cc055ba046f4b5be3349ff6bf98f2e793c3b969354aab2",
-    "https://deno.land/std@0.189.0/async/debounce.ts": "adab11d04ca38d699444ac8a9d9856b4155e8dda2afd07ce78276c01ea5a4332",
-    "https://deno.land/std@0.189.0/async/deferred.ts": "42790112f36a75a57db4a96d33974a936deb7b04d25c6084a9fa8a49f135def8",
-    "https://deno.land/std@0.189.0/async/delay.ts": "73aa04cec034c84fc748c7be49bb15cac3dd43a57174bfdb7a4aec22c248f0dd",
-    "https://deno.land/std@0.189.0/async/mod.ts": "f04344fa21738e5ad6bea37a6bfffd57c617c2d372bb9f9dcfd118a1b622e576",
-    "https://deno.land/std@0.189.0/async/mux_async_iterator.ts": "70c7f2ee4e9466161350473ad61cac0b9f115cff4c552eaa7ef9d50c4cbb4cc9",
-    "https://deno.land/std@0.189.0/async/pool.ts": "f1b8d3df4d7fd3c73f8cbc91cc2e8b8e950910f1eab94230b443944d7584c657",
-    "https://deno.land/std@0.189.0/async/retry.ts": "c9248325ec08cc2cceb7618472e77589a51a25cee460e07b6096be34966c2ead",
-    "https://deno.land/std@0.189.0/async/tee.ts": "47e42d35f622650b02234d43803d0383a89eb4387e1b83b5a40106d18ae36757",
-    "https://deno.land/std@0.189.0/fmt/colors.ts": "d67e3cd9f472535241a8e410d33423980bec45047e343577554d3356e1f0ef4e",
-    "https://deno.land/std@0.189.0/http/server.ts": "1b23463b5b36e4eebc495417f6af47a6f7d52e3294827a1226d2a1aab23d9d20",
-    "https://deno.land/std@0.189.0/semver/mod.ts": "200f50cf6872212667df532fb09f0b1a33d3427a5201f75fad30a0d0c6dbcce3",
-    "https://deno.land/std@0.189.0/testing/_diff.ts": "1a3c044aedf77647d6cac86b798c6417603361b66b54c53331b312caeb447aea",
-    "https://deno.land/std@0.189.0/testing/_format.ts": "a69126e8a469009adf4cf2a50af889aca364c349797e63174884a52ff75cf4c7",
-    "https://deno.land/std@0.189.0/testing/asserts.ts": "e16d98b4d73ffc4ed498d717307a12500ae4f2cbe668f1a215632d19fcffc22f",
-    "https://esm.sh/@octokit/webhooks-methods@3.0.2": "1d78d63ca59569b6b0953436871e23847fe0b6fa278f086234db2e66469accff",
-    "https://esm.sh/@octokit/webhooks@11.0.0": "5dd3affa37b7437f15716c3a851e254fada03bea1d7f5c8df12da44713a74567"
-  },
-  "workspace": {
-    "packageJson": {
-      "dependencies": [
-        "npm:typescript@5.5.3"
-      ]
+  "packages": {
+    "specifiers": {
+      "jsr:@std/assert@^0.196.0": "jsr:@std/assert@0.196.0",
+      "jsr:@std/async@0.196.0": "jsr:@std/async@0.196.0",
+      "jsr:@std/async@^0.196.0": "jsr:@std/async@0.196.0",
+      "jsr:@std/datetime@^0.196.0": "jsr:@std/datetime@0.196.0",
+      "jsr:@std/encoding@^0.196.0": "jsr:@std/encoding@0.196.0",
+      "jsr:@std/fmt@^0.196.0": "jsr:@std/fmt@0.196.0",
+      "jsr:@std/http@0.196.0": "jsr:@std/http@0.196.0",
+      "jsr:@std/internal@^0.196.0": "jsr:@std/internal@0.196.0",
+      "jsr:@std/semver@0.196.0": "jsr:@std/semver@0.196.0",
+      "jsr:@std/testing@0.196.0": "jsr:@std/testing@0.196.0",
+      "npm:@octokit/types@13.5.0": "npm:@octokit/types@13.5.0",
+      "npm:@octokit/webhooks-methods@3.0.2": "npm:@octokit/webhooks-methods@3.0.2",
+      "npm:@octokit/webhooks@11.0.0": "npm:@octokit/webhooks@11.0.0"
+    },
+    "jsr": {
+      "@std/assert@0.196.0": {
+        "integrity": "ede8c09c2bb176dc9356c04d2548412e492a58dcf73aad0965695a4d8336f66b",
+        "dependencies": [
+          "jsr:@std/fmt@^0.196.0",
+          "jsr:@std/internal@^0.196.0"
+        ]
+      },
+      "@std/async@0.196.0": {
+        "integrity": "bd572776dfdf94bcbe00ceea1263e06f0c0060ff258f8a5cf644c5b43992755a",
+        "dependencies": [
+          "jsr:@std/assert@^0.196.0"
+        ]
+      },
+      "@std/datetime@0.196.0": {
+        "integrity": "15353ada79e4f04ee7ac2dcab214184f270b72d81e99cc7b0a7f12eb4d2da264"
+      },
+      "@std/encoding@0.196.0": {
+        "integrity": "51740b1e602b24cc15373856e86650b29647fa333268e0614ee72ecb491bc4fb"
+      },
+      "@std/fmt@0.196.0": {
+        "integrity": "a9f398fbf7801bb5bd086f26800fcd5c32a2374eea176d20214dc461223fab66"
+      },
+      "@std/http@0.196.0": {
+        "integrity": "c1a1b52d62b8587e719b388228ebf585589990c746f837f75d984f25ee99006d",
+        "dependencies": [
+          "jsr:@std/assert@^0.196.0",
+          "jsr:@std/async@^0.196.0",
+          "jsr:@std/datetime@^0.196.0",
+          "jsr:@std/encoding@^0.196.0"
+        ]
+      },
+      "@std/internal@0.196.0": {
+        "integrity": "510a868cd8dc7a5a4de15b3864961b0f25d4b5b314f1f7d1bf6a5dd9a56173c1"
+      },
+      "@std/semver@0.196.0": {
+        "integrity": "4de41c3c4ccb0b8676550de1b61b52dffd91225e414398522ef76d54d9b7833d"
+      },
+      "@std/testing@0.196.0": {
+        "integrity": "be64f07bc12c2d93d46c6a51fc35817f73ab47f8d8664fbd722e9255e1bc951a",
+        "dependencies": [
+          "jsr:@std/assert@^0.196.0"
+        ]
+      }
+    },
+    "npm": {
+      "@octokit/openapi-types@18.1.1": {
+        "integrity": "sha512-VRaeH8nCDtF5aXWnjPuEMIYf1itK/s3JYyJcWFJT8X9pSNnBtriDf7wlEWsGuhPLl4QIH4xM8fqTXDwJ3Mu6sw==",
+        "dependencies": {}
+      },
+      "@octokit/openapi-types@22.2.0": {
+        "integrity": "sha512-QBhVjcUa9W7Wwhm6DBFu6ZZ+1/t/oYxqc2tp81Pi41YNuJinbFRx8B133qVOrAaBbF7D/m0Et6f9/pZt9Rc+tg==",
+        "dependencies": {}
+      },
+      "@octokit/request-error@3.0.3": {
+        "integrity": "sha512-crqw3V5Iy2uOU5Np+8M/YexTlT8zxCfI+qu+LxUB7SZpje4Qmx3mub5DfEKSO8Ylyk0aogi6TYdf6kxzh2BguQ==",
+        "dependencies": {
+          "@octokit/types": "@octokit/types@9.3.2",
+          "deprecation": "deprecation@2.3.1",
+          "once": "once@1.4.0"
+        }
+      },
+      "@octokit/types@13.5.0": {
+        "integrity": "sha512-HdqWTf5Z3qwDVlzCrP8UJquMwunpDiMPt5er+QjGzL4hqr/vBVY/MauQgS1xWxCDT1oMx1EULyqxncdCY/NVSQ==",
+        "dependencies": {
+          "@octokit/openapi-types": "@octokit/openapi-types@22.2.0"
+        }
+      },
+      "@octokit/types@9.3.2": {
+        "integrity": "sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==",
+        "dependencies": {
+          "@octokit/openapi-types": "@octokit/openapi-types@18.1.1"
+        }
+      },
+      "@octokit/webhooks-methods@3.0.2": {
+        "integrity": "sha512-Vlnv5WBscf07tyAvfDbp7pTkMZUwk7z7VwEF32x6HqI+55QRwBTcT+D7DDjZXtad/1dU9E32x0HmtDlF9VIRaQ==",
+        "dependencies": {}
+      },
+      "@octokit/webhooks-types@6.11.0": {
+        "integrity": "sha512-AanzbulOHljrku1NGfafxdpTCfw2ENaWzH01N2vqQM+cUFbk868Cgh0xylz0JIM9BoKbfI++bdD6EYX0Q/UTEw==",
+        "dependencies": {}
+      },
+      "@octokit/webhooks@11.0.0": {
+        "integrity": "sha512-+cn1O4+ItqXwc9Yo0DVfcfxPgeIRjV2AGDOkG6fwNRwXHw2IIUE/HEaNaHLUTiVCvXbL/pv6swqd+bM/Eylu5Q==",
+        "dependencies": {
+          "@octokit/request-error": "@octokit/request-error@3.0.3",
+          "@octokit/webhooks-methods": "@octokit/webhooks-methods@3.0.2",
+          "@octokit/webhooks-types": "@octokit/webhooks-types@6.11.0",
+          "aggregate-error": "aggregate-error@3.1.0"
+        }
+      },
+      "aggregate-error@3.1.0": {
+        "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+        "dependencies": {
+          "clean-stack": "clean-stack@2.2.0",
+          "indent-string": "indent-string@4.0.0"
+        }
+      },
+      "clean-stack@2.2.0": {
+        "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+        "dependencies": {}
+      },
+      "deprecation@2.3.1": {
+        "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
+        "dependencies": {}
+      },
+      "indent-string@4.0.0": {
+        "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+        "dependencies": {}
+      },
+      "once@1.4.0": {
+        "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+        "dependencies": {
+          "wrappy": "wrappy@1.0.2"
+        }
+      },
+      "wrappy@1.0.2": {
+        "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+        "dependencies": {}
+      }
     }
+  },
+  "remote": {},
+  "workspace": {
+    "dependencies": [
+      "jsr:@std/async@0.196.0",
+      "jsr:@std/http@0.196.0",
+      "jsr:@std/semver@0.196.0",
+      "jsr:@std/testing@0.196.0",
+      "npm:@octokit/types@13.5.0",
+      "npm:@octokit/webhooks-methods@3.0.2",
+      "npm:@octokit/webhooks@11.0.0"
+    ]
   }
 }

--- a/src/giteaVersion.ts
+++ b/src/giteaVersion.ts
@@ -1,4 +1,4 @@
-import { SemVer } from "https://deno.land/std@0.189.0/semver/mod.ts";
+import { parse } from "@std/semver";
 import { getMilestones } from "./github.ts";
 
 export class GiteaVersion {
@@ -6,7 +6,7 @@ export class GiteaVersion {
   milestoneNumber: number;
 
   constructor(milestone: { title: string; number: number }) {
-    const semver = new SemVer(milestone.title);
+    const semver = parse(milestone.title);
     this.majorMinorVersion = `${semver.major}.${semver.minor}`;
     this.milestoneNumber = milestone.number;
   }

--- a/src/github.ts
+++ b/src/github.ts
@@ -1,4 +1,4 @@
-import * as semver from "https://deno.land/std@0.189.0/semver/mod.ts";
+import { valid, lt, parse } from "@std/semver";
 import { getPrBranchName } from "./git.ts";
 import { GiteaVersion } from "./giteaVersion.ts";
 import { backportPrExistsCache } from "./state.ts";
@@ -294,17 +294,17 @@ export const getMilestones = async (): Promise<Milestone[]> => {
   if (!response.ok) throw new Error(await response.text());
   const json = await response.json();
   const milestones: Milestone[] = json.filter((m: Milestone) =>
-    semver.valid(m.title)
+    valid(m.title)
   );
 
   // take only the earliest patch version of each minor version (e.g. 1.19.0, 1.19.1, 1.19.2 -> 1.19.0)
   const earliestPatchVersions: Record<string, Milestone> = {};
   for (const milestone of milestones) {
-    const version = new semver.SemVer(milestone.title);
+    const version = parse(milestone.title);
     const key = `${version.major}.${version.minor}`;
     if (
       !earliestPatchVersions[key] ||
-      semver.lt(milestone.title, earliestPatchVersions[key].title)
+      lt(milestone.title, earliestPatchVersions[key].title)
     ) {
       earliestPatchVersions[key] = milestone;
     }

--- a/src/github.ts
+++ b/src/github.ts
@@ -1,4 +1,4 @@
-import { valid, lt, parse } from "@std/semver";
+import { lt, parse, valid } from "@std/semver";
 import { getPrBranchName } from "./git.ts";
 import { GiteaVersion } from "./giteaVersion.ts";
 import { backportPrExistsCache } from "./state.ts";
@@ -293,9 +293,7 @@ export const getMilestones = async (): Promise<Milestone[]> => {
   );
   if (!response.ok) throw new Error(await response.text());
   const json = await response.json();
-  const milestones: Milestone[] = json.filter((m: Milestone) =>
-    valid(m.title)
-  );
+  const milestones: Milestone[] = json.filter((m: Milestone) => valid(m.title));
 
   // take only the earliest patch version of each minor version (e.g. 1.19.0, 1.19.1, 1.19.2 -> 1.19.0)
   const earliestPatchVersions: Record<string, Milestone> = {};

--- a/src/github_test.ts
+++ b/src/github_test.ts
@@ -1,7 +1,4 @@
-import {
-  assertEquals,
-  assertFalse,
-} from "@std/testing/asserts";
+import { assertEquals, assertFalse } from "@std/testing/asserts";
 import {
   backportPrExists,
   fetchBranch,

--- a/src/github_test.ts
+++ b/src/github_test.ts
@@ -1,7 +1,7 @@
 import {
   assertEquals,
   assertFalse,
-} from "https://deno.land/std@0.189.0/testing/asserts.ts";
+} from "@std/testing/asserts";
 import {
   backportPrExists,
   fetchBranch,

--- a/src/labels.ts
+++ b/src/labels.ts
@@ -6,7 +6,7 @@ import {
   removeLabel,
 } from "./github.ts";
 import { fetchGiteaVersions } from "./giteaVersion.ts";
-import { debounce } from "https://deno.land/std@0.189.0/async/mod.ts";
+import { debounce } from "@std/async";
 import type { PullRequest } from "./types.ts";
 
 // a relevant label is one that is used to control the merge queue,

--- a/src/mergeQueue.ts
+++ b/src/mergeQueue.ts
@@ -1,6 +1,6 @@
 import { fetchPendingMerge, removeLabel } from "./github.ts";
 import * as prActions from "./prActions.ts";
-import { debounce } from "https://deno.land/std@0.189.0/async/mod.ts";
+import { debounce } from "@std/async";
 
 const updateBranch = async () => {
   // fetch all PRs that are pending merge

--- a/src/milestones.ts
+++ b/src/milestones.ts
@@ -1,4 +1,4 @@
-import * as SemVer from "https://deno.land/std@0.189.0/semver/mod.ts";
+import * as SemVer from "@std/semver";
 import { fetchGiteaVersions } from "./giteaVersion.ts";
 import * as github from "./github.ts";
 import type { PullRequest } from "./types.ts";

--- a/src/prActions.ts
+++ b/src/prActions.ts
@@ -1,5 +1,5 @@
 import { addComment, needsUpdate, removeLabel, updatePr } from "./github.ts";
-import { debounce } from "https://deno.land/std@0.189.0/async/mod.ts";
+import { debounce } from "@std/async";
 
 const execute = async (
   label: string,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { Endpoints } from "npm:@octokit/types@13.5.0";
+import { Endpoints } from "@octokit/types";
 
 type IssueGetResponse =
   Endpoints["GET /repos/{owner}/{repo}/issues/{issue_number}"]["response"][

--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -1,6 +1,6 @@
-import { serve } from "https://deno.land/std@0.189.0/http/server.ts";
-import { createEventHandler } from "https://esm.sh/@octokit/webhooks@11.0.0";
-import { verify } from "https://esm.sh/@octokit/webhooks-methods@3.0.2";
+import { serve } from "@std/http";
+import { createEventHandler } from "@octokit/webhooks";
+import { verify } from "@octokit/webhooks-methods";
 import * as backport from "./backport.ts";
 import * as labels from "./labels.ts";
 import * as mergeQueue from "./mergeQueue.ts";


### PR DESCRIPTION
- Add deno.json with import maps
- Load the standard library from jsr as that seems [recommended nowadays](https://docs.deno.com/runtime/manual/basics/import_maps/#example---using-the-deno-standard-library) and I find it more managable than to have versions in each file.
- Bump standard library from 0.189.0 to 0.196.0 because that is the oldest version available on jsr.