### PR TITLE
Remind TOC to review PRs with `pr/last-call`

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ a maintainer through a `giteabot/*` label.
 ### Last call
 
 The script will close PRs with the label `pr/last-call` if two weeks have passed
-since they were updated.
+since they were updated. If one week has passed since they were updated, it will
+remind the TOC to review the PR.
 
 ## Usage
 

--- a/src/lastCall.ts
+++ b/src/lastCall.ts
@@ -1,4 +1,9 @@
-import { addComment, closePr, fetchOpenPrsWithLabel } from "./github.ts";
+import {
+  addComment,
+  addLabels,
+  closePr,
+  fetchOpenPrsWithLabel,
+} from "./github.ts";
 
 export const run = async () => {
   // get all issues with the label "pr/last-call"
@@ -8,14 +13,34 @@ export const run = async () => {
   return Promise.all(issuesWithStatusPrLastCall.items.map(handlePr));
 };
 
-// close PR if two weeks have passed since it was last updated
+// close PR if two weeks have passed since it was last updated. Remind TOC if one week has passed
 const handlePr = async (pr: {
   number: number;
   updated_at: string;
+  labels: { name: string }[];
 }) => {
+  const lastPrUpdateTime = new Date(pr.updated_at).getTime();
+  const oneWeekAgo = (new Date(Date.now() - 1000 * 60 * 60 * 24 * 7))
+    .getTime();
+
+  if (
+    lastPrUpdateTime < oneWeekAgo &&
+    pr.labels.some((l) => l.name === "lgtm/need 1") &&
+    !pr.labels.some((l) => l.name === "giteabot/toc-reminded")
+  ) {
+    console.log(`Reminding PR #${pr.number} due to pr/last-call timeout`);
+    await addComment(
+      pr.number,
+      "This pull request has a last call and has not had any activity in the past week. @go-gitea/technical-oversight-committee please review this pull request and either merge it or request a review from a maintainer. :tea:",
+    );
+    await addLabels(pr.number, ["giteabot/toc-reminded"]);
+    return;
+  }
+
   const twoWeeksAgo = (new Date(Date.now() - 1000 * 60 * 60 * 24 * 14))
     .getTime();
-  if ((new Date(pr.updated_at)).getTime() < twoWeeksAgo) {
+
+  if (lastPrUpdateTime < twoWeeksAgo) {
     console.log(`Closing PR #${pr.number} due to pr/last-call timeout`);
     await addComment(
       pr.number,


### PR DESCRIPTION
If a week has passed since the final call, add a comment reminding TOC to review.

**This requires a new label to be added `giteabot/toc-reminded`.**

- Closes https://github.com/GiteaBot/gitea-backporter/issues/136