### PR TITLE
Add debug logs for `removeBackportLabelsFromPrs`

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -2,6 +2,7 @@ import { lt, parse, valid } from "@std/semver";
 import { getPrBranchName } from "./git.ts";
 import { GiteaVersion } from "./giteaVersion.ts";
 import { backportPrExistsCache } from "./state.ts";
+import { PullRequest } from "./types.ts";
 
 const GITHUB_API = "https://api.github.com";
 const HEADERS = {
@@ -85,7 +86,9 @@ export const fetchPendingMerge = async () => {
 };
 
 // returns a list of PRs that target the given branch
-export const fetchTargeting = async (branch: string) => {
+export const fetchTargeting = async (
+  branch: string,
+): Promise<{ items: PullRequest[] }> => {
   const response = await fetch(
     `${GITHUB_API}/search/issues?q=` +
       encodeURIComponent(

--- a/src/labels.ts
+++ b/src/labels.ts
@@ -72,6 +72,10 @@ export const removeBackportLabelsFromPrsTargetingReleaseBranches = async () => {
   // versions
   return Promise.all(giteaVersions.map(async (version) => {
     const prs = await fetchTargeting(`release/v${version.majorMinorVersion}`);
+    console.info(
+      `Removing backport/* labels from PRs targeting v${version.majorMinorVersion}. The raw response from GitHub is:`,
+    );
+    console.info(JSON.stringify(prs));
     // PRs
     return removeBackportLabelsFromPrs(prs.items);
   }));


### PR DESCRIPTION
From the logs:

```log
2024-10-19 15:52:16.292	error: Uncaught (in promise) Error: removeBackportLabelsFromPrs called with undefined
2024-10-19 15:52:16.292	throw new Error("removeBackportLabelsFromPrs called with undefined");
2024-10-19 15:52:16.292	          ^
2024-10-19 15:52:16.292	at removeBackportLabelsFromPrs (file:///app/src/labels.ts:83:11)
2024-10-19 15:52:16.292	at file:///app/src/labels.ts:76:12
2024-10-19 15:52:16.292	at eventLoopTick (ext:core/01_core.js:175:7)
2024-10-19 15:52:16.292	at async Promise.all (index 1)
2024-10-19 15:52:16.292	at async Promise.all (index 1)
2024-10-19 15:52:16.292	at async Function.maintain (file:///app/src/labels.ts:26:3)
```

- Follows https://github.com/GiteaBot/gitea-backporter/pull/129