### PR TITLE
Catch an error instead of crashing

### DIFF
--- a/src/labels.ts
+++ b/src/labels.ts
@@ -72,12 +72,13 @@ export const removeBackportLabelsFromPrsTargetingReleaseBranches = async () => {
   // versions
   return Promise.all(giteaVersions.map(async (version) => {
     const prs = await fetchTargeting(`release/v${version.majorMinorVersion}`);
-    console.info(
-      `Removing backport/* labels from PRs targeting v${version.majorMinorVersion}. The raw response from GitHub is:`,
-    );
-    console.info(JSON.stringify(prs));
     // PRs
-    return removeBackportLabelsFromPrs(prs.items);
+    try {
+      return removeBackportLabelsFromPrs(prs.items);
+    } catch (error) {
+      // we usually get here when GitHub rate limits us
+      console.error(error, JSON.stringify(prs));
+    }
   }));
 };
 


### PR DESCRIPTION
It was rate-limiting.

- Follows https://github.com/GiteaBot/gitea-backporter/pull/138