### PR TITLE
Exclude 'en-US.json' from translation checks

### DIFF
--- a/src/comments.ts
+++ b/src/comments.ts
@@ -8,7 +8,7 @@ export const commentIfTranslationsChanged = async (
   const translationsChanged = prFileNames.some((fileName) =>
     fileName.startsWith("options/locale/") &&
     (fileName.endsWith(".ini") || fileName.endsWith(".json")) &&
-    !fileName.endsWith("en-US.ini")
+    !fileName.endsWith("en-US.ini") && !fileName.endsWith("en-US.json")
   );
   if (translationsChanged) {
     const comment =


### PR DESCRIPTION
Fix the wrongly reminder when `en-US.json` file changed.